### PR TITLE
Add check for `__name__ == "__main__"` to launcher script template

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -165,8 +165,9 @@ if appdata:
 
 {extra_preamble}
 
-from {module} import {func}
-{func}()
+if __name__ == '__main__':
+    from {module} import {func}
+    {func}()
 """
     
     def write_script(self, entrypt, target, extra_preamble=''):


### PR DESCRIPTION
I just ran into a problem with my pynsist-packaged application.

The issue was that due to the lack of `fork()` on Windows, the `multiprocessing` module seems to clone the process.
This had the unintended consequence of running all of my initialization code all over again, resulting in errors (e.g. because we try to bind to the same port twice, etc).
Adding a check for `if __name__ == '__main__'` to the launcher script, [as recommended by the Python docs](https://docs.python.org/2/library/multiprocessing.html#windows) resolved the issue.
