### PR TITLE
Fix a bug in the exclude option in cross-platform environments

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -89,7 +89,7 @@ class InstallerBuilder(object):
         self.shortcuts = shortcuts
         self.icon = icon
         self.packages = packages or []
-        self.exclude = exclude or []
+        self.exclude = [os.path.normpath(p) for p in (exclude or [])]
         self.extra_files = extra_files or []
         self.py_version = py_version
         if not self._py_version_pattern.match(py_version):
@@ -268,6 +268,7 @@ if __name__ == '__main__':
         ignored = set()
 
         # Filter by file names relative to the build directory
+        directory = os.path.normpath(directory)
         files = [os.path.join(directory, fname) for fname in files]
 
         # Execute all patterns

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -73,8 +73,8 @@ def copytree_ignore_callback(excludes, pkgdir, modname, directory, files):
 
     # Filter by file names relative to the build directory
     reldir = os.path.relpath(directory, pkgdir)
-    target = os.path.join('pkgs/', modname, reldir)
-    files = [os.path.join(target, fname) for fname in files]
+    target = os.path.join('pkgs', modname, reldir)
+    files = [os.path.normpath(os.path.join(target, fname)) for fname in files]
 
     # Execute all patterns
     for pattern in excludes + ['*.pyc']:


### PR DESCRIPTION
I recently contributed the ``exclude`` configuration option (and of course, tested it) and now, that pynsist 1.5 is released I started using it in production.

However, if used it in a Linux/Windows environment, it is very easy to make the setting ineffective by mixing forward and backward slashes as path seperators.

Additionally, there was a bug which lead to exclusions not working in the root directory of a package because of a ``/./`` in a generated path. Running ``os.path.normpath`` over both package directories and exclusion patterns fixes the problem.