### PR TITLE
Add PyGI / PyGObject example

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -12,7 +12,7 @@ with different frameworks:
 - `A PyQt4 application <https://github.com/takluyver/pynsist/tree/master/examples/pyqt>`_
 - `A PyGTK application <https://github.com/takluyver/pynsist/tree/master/examples/pygtk>`_
 - `A PyGTK application including Numpy and Matplotlib (32 bit, Python 2.7) <https://github.com/takluyver/pynsist/tree/master/examples/pygtk_mpl_numpy>`_
-- `A PyGTK application including Numpy and Matplotlib (64 bit, Python 3.4) <https://github.com/takluyver/pynsist/tree/master/examples/pygi_mpl_numpy>`_
+- `A PyGI (or PyGObject) application including Numpy and Matplotlib (64 bit, Python 3.4) <https://github.com/takluyver/pynsist/tree/master/examples/pygi_mpl_numpy>`_
 - `A pygame application <https://github.com/takluyver/pynsist/tree/master/examples/pygame>`_
 
 Real-world examples

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -12,6 +12,7 @@ with different frameworks:
 - `A PyQt4 application <https://github.com/takluyver/pynsist/tree/master/examples/pyqt>`_
 - `A PyGTK application <https://github.com/takluyver/pynsist/tree/master/examples/pygtk>`_
 - `A PyGTK application including Numpy and Matplotlib (32 bit, Python 2.7) <https://github.com/takluyver/pynsist/tree/master/examples/pygtk_mpl_numpy>`_
+- `A PyGTK application including Numpy and Matplotlib (64 bit, Python 3.4) <https://github.com/takluyver/pynsist/tree/master/examples/pygi_mpl_numpy>`_
 - `A pygame application <https://github.com/takluyver/pynsist/tree/master/examples/pygame>`_
 
 Real-world examples

--- a/examples/build_all_examples.py
+++ b/examples/build_all_examples.py
@@ -8,6 +8,7 @@ example_cfgs = [
     'pygame/installer.cfg',
     'pygtk/installer.cfg',
     'pygtk_mpl_numpy/installer.cfg',
+    'pygi_mpl_numpy/installer.cfg',
 ]
 
 examples_dir = os.path.dirname(os.path.abspath(__file__))

--- a/examples/pygi_mpl_numpy/1_download.sh
+++ b/examples/pygi_mpl_numpy/1_download.sh
@@ -1,0 +1,4 @@
+# Download the necessary files
+# Python-GI bindings, Matplotlib (64-bit, Python 3.4)
+wget -O pygi.exe http://downloads.sourceforge.net/project/pygobjectwin32/pygi-aio-3.14.0_rev13-setup.exe
+wget -O matplotlib.exe http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.4.3/windows/matplotlib-1.4.3.win-amd64-py3.4.exe

--- a/examples/pygi_mpl_numpy/2_extract.sh
+++ b/examples/pygi_mpl_numpy/2_extract.sh
@@ -1,4 +1,4 @@
-# Extract files and place them in the pynsist_pkgs folder
+# Extracts all dependencies and places them in the pynsist_pkgs folder
 
 mkdir pynsist_pkgs
 
@@ -18,86 +18,20 @@ rm -r numpy
 cp -r bindings/* pynsist_pkgs
 rm -r bindings
 
-# ATK
-7z x pygi/noarch/ATK/ATK.data.7z -oATKnoarch
-cp -r ATKnoarch/gnome/* pynsist_pkgs/gnome
-rm -r ATKnoarch
+# Copy the noarch and specified architecture dependencies into the gnome folder
+array=( ATK Base GDK GDKPixbuf GTK JPEG Pango WebP TIFF )
 
-7z x pygi/rtvc10-64/ATK/ATK.bin.7z -oATK
-cp -r ATK/gnome/* pynsist_pkgs/gnome
-rm -r ATK
+for i in "${array[@]}"
+do
+    echo -e "\nProcessing $i dependency"
+    7z x pygi/noarch/$i/$i.data.7z -o$i-noarch
+    cp -r $i-noarch/gnome/* pynsist_pkgs/gnome
+    rm -r $i-noarch
 
-# Base
-7z x pygi/noarch/Base/Base.data.7z -oBasenoarch
-cp -r Basenoarch/gnome/* pynsist_pkgs/gnome
-rm -r Basenoarch
-
-7z x pygi/rtvc10-64/Base/Base.bin.7z -oBase
-cp -r Base/gnome/* pynsist_pkgs/gnome
-rm -r Base
-
-# GDK
-7z x pygi/noarch/GDK/GDK.data.7z -oGDKnoarch
-cp -r GDKnoarch/gnome/* pynsist_pkgs/gnome
-rm -r GDKnoarch
-
-7z x pygi/rtvc10-64/GDK/GDK.bin.7z -oGDK
-cp -r GDK/gnome/* pynsist_pkgs/gnome
-rm -r GDK
-
-# GDKPixbuf
-7z x pygi/noarch/GDKPixbuf/GDKPixbuf.data.7z -oGDKPixbufnoarch
-cp -r GDKPixbufnoarch/gnome/* pynsist_pkgs/gnome
-rm -r GDKPixbufnoarch
-
-7z x pygi/rtvc10-64/GDKPixbuf/GDKPixbuf.bin.7z -oGDKPixbuf
-cp -r GDKPixbuf/gnome/* pynsist_pkgs/gnome
-rm -r GDKPixbuf
-
-# GTK
-7z x pygi/noarch/GTK/GTK.data.7z -oGTKnoarch
-cp -r GTKnoarch/gnome/* pynsist_pkgs/gnome
-rm -r GTKnoarch
-
-7z x pygi/rtvc10-64/GTK/GTK.bin.7z -oGTK
-cp -r GTK/gnome/* pynsist_pkgs/gnome
-rm -r GTK
-
-# JPEG
-7z x pygi/noarch/JPEG/JPEG.data.7z -oJPEGnoarch
-cp -r JPEGnoarch/gnome/* pynsist_pkgs/gnome
-rm -r JPEGnoarch
-
-7z x pygi/rtvc10-64/JPEG/JPEG.bin.7z -oJPEG
-cp -r JPEG/gnome/* pynsist_pkgs/gnome
-rm -r JPEG
-
-# Pango
-7z x pygi/noarch/Pango/Pango.data.7z -oPangonoarch
-cp -r Pangonoarch/gnome/* pynsist_pkgs/gnome
-rm -r Pangonoarch
-
-7z x pygi/rtvc10-64/Pango/Pango.bin.7z -oPango
-cp -r Pango/gnome/* pynsist_pkgs/gnome
-rm -r Pango
-
-# WebP
-7z x pygi/noarch/WebP/WebP.data.7z -oWebPnoarch
-cp -r WebPnoarch/gnome/* pynsist_pkgs/gnome
-rm -r WebPnoarch
-
-7z x pygi/rtvc10-64/WebP/WebP.bin.7z -oWebP
-cp -r WebP/gnome/* pynsist_pkgs/gnome
-rm -r WebP
-
-# TIFF
-7z x pygi/noarch/TIFF/TIFF.data.7z -oTIFFnoarch
-cp -r TIFFnoarch/gnome/* pynsist_pkgs/gnome
-rm -r TIFFnoarch
-
-7z x pygi/rtvc10-64/TIFF/TIFF.bin.7z -oTIFF
-cp -r TIFF/gnome/* pynsist_pkgs/gnome
-rm -r TIFF
+    7z x pygi/rtvc10-64/$i/$i.bin.7z -o$i-arch
+    cp -r $i-arch/gnome/* pynsist_pkgs/gnome
+    rm -r $i-arch
+done
 
 #Remove pygi Folder
 rm -r pygi

--- a/examples/pygi_mpl_numpy/2_extract.sh
+++ b/examples/pygi_mpl_numpy/2_extract.sh
@@ -1,0 +1,103 @@
+# Extract files and place them in the pynsist_pkgs folder
+
+mkdir pynsist_pkgs
+
+# Unzip the bindings
+7z x numpy.whl -onumpy
+7z x matplotlib.exe -omatplotlib
+7z x pygi.exe -opygi
+
+# Copy matplotlib and numpy into the pynsist_pkgs folder and delete the folders
+cp -r matplotlib/PLATLIB/matplotlib pynsist_pkgs
+rm -r matplotlib
+cp -r numpy/numpy pynsist_pkgs
+rm -r numpy
+
+# Copy the PyGI packages into the pynsist_pkgs folder
+7z x pygi/binding/py3.4-64/py3.4-64.7z -obindings
+cp -r bindings/* pynsist_pkgs
+rm -r bindings
+
+# ATK
+7z x pygi/noarch/ATK/ATK.data.7z -oATKnoarch
+cp -r ATKnoarch/gnome/* pynsist_pkgs/gnome
+rm -r ATKnoarch
+
+7z x pygi/rtvc10-64/ATK/ATK.bin.7z -oATK
+cp -r ATK/gnome/* pynsist_pkgs/gnome
+rm -r ATK
+
+# Base
+7z x pygi/noarch/Base/Base.data.7z -oBasenoarch
+cp -r Basenoarch/gnome/* pynsist_pkgs/gnome
+rm -r Basenoarch
+
+7z x pygi/rtvc10-64/Base/Base.bin.7z -oBase
+cp -r Base/gnome/* pynsist_pkgs/gnome
+rm -r Base
+
+# GDK
+7z x pygi/noarch/GDK/GDK.data.7z -oGDKnoarch
+cp -r GDKnoarch/gnome/* pynsist_pkgs/gnome
+rm -r GDKnoarch
+
+7z x pygi/rtvc10-64/GDK/GDK.bin.7z -oGDK
+cp -r GDK/gnome/* pynsist_pkgs/gnome
+rm -r GDK
+
+# GDKPixbuf
+7z x pygi/noarch/GDKPixbuf/GDKPixbuf.data.7z -oGDKPixbufnoarch
+cp -r GDKPixbufnoarch/gnome/* pynsist_pkgs/gnome
+rm -r GDKPixbufnoarch
+
+7z x pygi/rtvc10-64/GDKPixbuf/GDKPixbuf.bin.7z -oGDKPixbuf
+cp -r GDKPixbuf/gnome/* pynsist_pkgs/gnome
+rm -r GDKPixbuf
+
+# GTK
+7z x pygi/noarch/GTK/GTK.data.7z -oGTKnoarch
+cp -r GTKnoarch/gnome/* pynsist_pkgs/gnome
+rm -r GTKnoarch
+
+7z x pygi/rtvc10-64/GTK/GTK.bin.7z -oGTK
+cp -r GTK/gnome/* pynsist_pkgs/gnome
+rm -r GTK
+
+# JPEG
+7z x pygi/noarch/JPEG/JPEG.data.7z -oJPEGnoarch
+cp -r JPEGnoarch/gnome/* pynsist_pkgs/gnome
+rm -r JPEGnoarch
+
+7z x pygi/rtvc10-64/JPEG/JPEG.bin.7z -oJPEG
+cp -r JPEG/gnome/* pynsist_pkgs/gnome
+rm -r JPEG
+
+# Pango
+7z x pygi/noarch/Pango/Pango.data.7z -oPangonoarch
+cp -r Pangonoarch/gnome/* pynsist_pkgs/gnome
+rm -r Pangonoarch
+
+7z x pygi/rtvc10-64/Pango/Pango.bin.7z -oPango
+cp -r Pango/gnome/* pynsist_pkgs/gnome
+rm -r Pango
+
+# WebP
+7z x pygi/noarch/WebP/WebP.data.7z -oWebPnoarch
+cp -r WebPnoarch/gnome/* pynsist_pkgs/gnome
+rm -r WebPnoarch
+
+7z x pygi/rtvc10-64/WebP/WebP.bin.7z -oWebP
+cp -r WebP/gnome/* pynsist_pkgs/gnome
+rm -r WebP
+
+# TIFF
+7z x pygi/noarch/TIFF/TIFF.data.7z -oTIFFnoarch
+cp -r TIFFnoarch/gnome/* pynsist_pkgs/gnome
+rm -r TIFFnoarch
+
+7z x pygi/rtvc10-64/TIFF/TIFF.bin.7z -oTIFF
+cp -r TIFF/gnome/* pynsist_pkgs/gnome
+rm -r TIFF
+
+#Remove pygi Folder
+rm -r pygi

--- a/examples/pygi_mpl_numpy/README.rst
+++ b/examples/pygi_mpl_numpy/README.rst
@@ -1,0 +1,68 @@
+This example shows how to package a program that uses the PyGI-bindings of Gtk (or PyGObject). Python 3.4.3 64-bit will be used together with 64-bit dependencies.
+
+The example program conists of a window with a matplotlib-plot and a button that triggers the window to close.
+
+Requirements
+------------
+
+This example needs 7zip in order to work. You can install it for example on
+Debian-style distributions using:
+
+::
+
+    sudo apt-get install p7zip
+
+Building the program
+--------------------
+
+A shell script can be used to download some of the dependencies:
+
+::
+
+    sh 1_download.sh
+
+The numpy 64-bit wheel can be downloaded here (numpy‑1.9.2+mkl‑cp34‑none‑win_amd64.whl):
+
+http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy
+
+Rename it to numpy.whl before starting the second script.
+
+The next script will copy all the dependencies into the ``pynsist_pkgs`` folder.
+
+::
+
+    sh 2_extract.sh
+
+After that, the example can be built using this command:
+
+::
+
+    python3 -m nsist installer.cfg
+
+Installer.cfg
+-------------
+
+The example uses 64-bit Python 3.4 and 64-bit dependencies. This is expressed in the
+``installer.cfg``-file like this:
+
+::
+
+    version=3.4.3
+    bitness=64
+
+The include section requires the Python packages numpy, matplotlib (which are taken from the ``pynsist_pkgs`` folder). In addition the packages six, dateutil and pyparsing are required. From the pygi-bindings the top level packages cairo, dbus, gi, gnome and pygtkcompat have to be listed here (They are also in the top level of the ``pynsist_pkgs`` directory). The ``gnome``-folder contains the dependencies ATK, Base, GDK, GDKPixbuf, GTK, JPEG, Pango, WebP and TIFF.
+
+::
+
+    [Include]
+    packages=gi
+        cairo
+        dbus
+        gnome
+        pygtkcompat
+        numpy
+        matplotlib
+        six
+        dateutil
+        pyparsing
+

--- a/examples/pygi_mpl_numpy/gnome_preamble.py
+++ b/examples/pygi_mpl_numpy/gnome_preamble.py
@@ -1,0 +1,1 @@
+os.environ['PATH'] += os.pathsep + os.path.join(pkgdir, 'gnome')

--- a/examples/pygi_mpl_numpy/installer.cfg
+++ b/examples/pygi_mpl_numpy/installer.cfg
@@ -1,0 +1,21 @@
+[Application]
+name=hello-pygi
+version=1.0
+entry_point=pygi_test:main
+extra_preamble=gnome_preamble.py
+
+[Python]
+version=3.4.3
+bitness=64
+
+[Include]
+packages=gi
+    cairo
+    dbus
+    gnome
+    pygtkcompat
+    numpy
+    matplotlib
+    six
+    dateutil
+    pyparsing

--- a/examples/pygi_mpl_numpy/pygi_test.py
+++ b/examples/pygi_mpl_numpy/pygi_test.py
@@ -3,8 +3,8 @@
 """
 This test program utilizes the Python bindings for GTK3 (PyGI or PyGObject).
 
-The program conists of a windows with a button that closes the windows when
-clicked. The windows also shows a matplotlib plot. The plot is based on this
+The program conists of a window with a button that closes the window when
+clicked. The window also shows a matplotlib plot. The plot is based on this
 example: http://matplotlib.org/examples/pie_and_polar_charts/polar_bar_demo.html
 """
 

--- a/examples/pygi_mpl_numpy/pygi_test.py
+++ b/examples/pygi_mpl_numpy/pygi_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+"""
+This test program utilizes the Python bindings for GTK3 (PyGI or PyGObject).
+
+The program conists of a windows with a button that closes the windows when
+clicked. The windows also shows a matplotlib plot. The plot is based on this
+example: http://matplotlib.org/examples/pie_and_polar_charts/polar_bar_demo.html
+"""
+
+from gi.repository import Gtk
+from matplotlib.backends.backend_gtk3cairo import FigureCanvasGTK3Cairo as FigureCanvas
+from matplotlib.figure import Figure
+import matplotlib.cm as cm
+import numpy as np
+
+
+class MyWindow(Gtk.Window):
+    def __init__(self):
+        Gtk.Window.__init__(self, title="PyGI / PyGObject Example")
+        self.connect("delete-event", Gtk.main_quit)
+        self.set_default_size(400, 400)
+
+        self.box = Gtk.Box(spacing=6, orientation=Gtk.Orientation.VERTICAL)
+        self.add(self.box)
+
+        self.fig = Figure(figsize=(10,10), dpi=80)
+        self.ax = self.fig.add_subplot(111, polar=True)
+
+        N = 20
+        theta = np.linspace(0.0, 2 * np.pi, N, endpoint=False)
+        radii = 10 * np.random.rand(N)
+        width = np.pi / 4 * np.random.rand(N)
+        bars = self.ax.bar(theta, radii, width=width, bottom=0.0)
+        for r, bar in zip(radii, bars):
+            bar.set_facecolor(cm.jet(r / 10.))
+            bar.set_alpha(0.5)
+
+        self.canvas = FigureCanvas(self.fig)
+        self.box.pack_start(self.canvas, True, True, 0)
+
+        self.button = Gtk.Button(label="Exit")
+        self.button.connect("clicked", self.on_exit_clicked)
+        self.box.pack_start(self.button, False, False, 0)
+
+    def on_exit_clicked(self, widget):
+        Gtk.main_quit()
+
+def main():
+    win = MyWindow()
+    win.show_all()
+    Gtk.main()


### PR DESCRIPTION
A PyGI (or PyGObject) example would be helpful, because packaging this dependency is not trivial and different than for PyGTK.

I could not get the shell script to download the 64-bit numpy package from http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy - The Readme explains where to manually download it.