### PR TITLE
Update PyGI/PyGObject example to compile glib-schemas

### DIFF
--- a/examples/pygi_mpl_numpy/2_extract.sh
+++ b/examples/pygi_mpl_numpy/2_extract.sh
@@ -35,3 +35,6 @@ done
 
 #Remove pygi Folder
 rm -r pygi
+
+#Compile glib schemas
+glib-compile-schemas pynsist_pkgs/gnome/share/glib-2.0/schemas/

--- a/examples/pygi_mpl_numpy/README.rst
+++ b/examples/pygi_mpl_numpy/README.rst
@@ -66,3 +66,19 @@ The include section requires the Python packages numpy, matplotlib (which are ta
         dateutil
         pyparsing
 
+Compiling
+---------
+
+When the pygi-aio bundle is installed on a Windows-machine, the installer performs some post-installation compiling steps. After extracting the libraries from the bundle, compiling can be carried out on Linux, as long as the operating system used for packaging and the targeted operating system have the same bitness. For different bitnesses, use a virtual machine with desired bitness, install the bundle, and copy the compiled files back into your build directory.
+
+An example are the ``glib-schemas`` which are required for the GtkFileChooserDialog to work properly. The script ``2_extract.sh`` will automatically call the following command to compile the ``glib-schemas``:
+
+::
+
+    glib-compile-schemas pynsist_pkgs/gnome/share/glib-2.0/schemas/
+
+See also:
+
+ - https://github.com/takluyver/pynsist/issues/43
+ - https://sourceforge.net/p/pygobjectwin32/tickets/12/
+

--- a/examples/pygi_mpl_numpy/README.rst
+++ b/examples/pygi_mpl_numpy/README.rst
@@ -66,12 +66,12 @@ The include section requires the Python packages numpy, matplotlib (which are ta
         dateutil
         pyparsing
 
-Compiling
----------
+glib-schemas
+------------
 
 When the pygi-aio bundle is installed on a Windows-machine, the installer performs some post-installation compiling steps. After extracting the libraries from the bundle, compiling can be carried out on Linux, as long as the operating system used for packaging and the targeted operating system have the same bitness. For different bitnesses, use a virtual machine with desired bitness, install the bundle, and copy the compiled files back into your build directory.
 
-An example are the ``glib-schemas`` which are required for the GtkFileChooserDialog to work properly. The script ``2_extract.sh`` will automatically call the following command to compile the ``glib-schemas``:
+An example are the glib-schemas which are required for the GtkFileChooserDialog to work properly. The script ``2_extract.sh`` will automatically call the following command to compile the glib-schemas:
 
 ::
 


### PR DESCRIPTION
I updated the script to compile the glib-schemas after all the libraries are copied in the `pynsist_pkgs` folder. The readme explains why the compiling is necessary. Linking to the bug-reports should help people that encounter a crash because of uncompiled schemas.

Relevant bug report:

 - https://github.com/takluyver/pynsist/issues/43