### PR TITLE
Updating pygi_mpl_numpy example to pygi-aio-rev21

### DIFF
--- a/examples/pygi_mpl_numpy/1_download.sh
+++ b/examples/pygi_mpl_numpy/1_download.sh
@@ -1,4 +1,4 @@
 # Download the necessary files
 # Python-GI bindings, Matplotlib (64-bit, Python 3.4)
-wget -O pygi.exe http://downloads.sourceforge.net/project/pygobjectwin32/pygi-aio-3.14.0_rev13-setup.exe
+wget -O pygi.exe http://sourceforge.net/projects/pygobjectwin32/files/pygi-aio-3.14.0_rev21-setup.exe
 wget -O matplotlib.exe http://downloads.sourceforge.net/project/matplotlib/matplotlib/matplotlib-1.4.3/windows/matplotlib-1.4.3.win-amd64-py3.4.exe

--- a/examples/pygi_mpl_numpy/2_extract.sh
+++ b/examples/pygi_mpl_numpy/2_extract.sh
@@ -1,4 +1,5 @@
 # Extracts all dependencies and places them in the pynsist_pkgs folder
+# You might need to rename the "7z" calls to "7za" depending on your distribution
 
 mkdir pynsist_pkgs
 
@@ -19,7 +20,7 @@ cp -r bindings/* pynsist_pkgs
 rm -r bindings
 
 # Copy the noarch and specified architecture dependencies into the gnome folder
-array=( ATK Base GDK GDKPixbuf GTK JPEG Pango WebP TIFF )
+array=( ATK Base GDK GDKPixbuf GTK HarfBuzz JPEG Pango WebP TIFF )
 
 for i in "${array[@]}"
 do

--- a/examples/pygi_mpl_numpy/README.rst
+++ b/examples/pygi_mpl_numpy/README.rst
@@ -73,11 +73,11 @@ When the pygi-aio bundle is installed on a Windows-machine, the installer perfor
 
 An example are the glib-schemas which are required for the GtkFileChooserDialog to work properly. The script ``2_extract.sh`` will automatically call the following command to compile the glib-schemas:
 
-Note: If your application uses glib-schemas (e.g. default-settings stored in gsettings) you will need to place the schemas for your application into that folder and recompile it before packaging it with Pynsist.
-
 ::
 
     glib-compile-schemas pynsist_pkgs/gnome/share/glib-2.0/schemas/
+
+Note: If your application uses glib-schemas (e.g. default-settings stored in gsettings) you will need to place the schemas for your application into that folder and recompile it before packaging it with Pynsist.
 
 See also:
 

--- a/examples/pygi_mpl_numpy/README.rst
+++ b/examples/pygi_mpl_numpy/README.rst
@@ -73,6 +73,8 @@ When the pygi-aio bundle is installed on a Windows-machine, the installer perfor
 
 An example are the glib-schemas which are required for the GtkFileChooserDialog to work properly. The script ``2_extract.sh`` will automatically call the following command to compile the glib-schemas:
 
+Note: If your application uses glib-schemas (e.g. default-settings stored in gsettings) you will need to place the schemas for your application into that folder and recompile it before packaging it with Pynsist.
+
 ::
 
     glib-compile-schemas pynsist_pkgs/gnome/share/glib-2.0/schemas/
@@ -81,4 +83,3 @@ See also:
 
  - https://github.com/takluyver/pynsist/issues/43
  - https://sourceforge.net/p/pygobjectwin32/tickets/12/
-


### PR DESCRIPTION
This PR updates the `pygi_mpl_numpy` example to rev21 of the Python-GI bundle for Windows. Thanks to @xor for reporting the issue and providing the fix.

The PR resolves this issue:

 - https://github.com/takluyver/pynsist/issues/52

I tested the example program on Windows 7 and it did not trigger any warnings.