### PR TITLE
Make Python version not mandatory

### DIFF
--- a/nsist/configreader.py
+++ b/nsist/configreader.py
@@ -73,7 +73,7 @@ CONFIG_VALIDATORS = {
         ('exclude', False),
     ]),
     'Python': SectionValidator([
-        ('version', True),
+        ('version', False),
         ('bitness', False),
         ('format', False),
     ]),


### PR DESCRIPTION
I had a look at how you were reading and validating the configuration file and it seems this simple modification is enough to avoid having to provide the Python version when we want only to force the bitness (as discussed in #49). I thought it would be more complex, but turns out you already had a fallback prepared.

You mentioned that it defaults to the Python version it is running in, but looks like `DEFAULT_PY_VERSION` is fixed... but I'm not touching there because that is a different issue.