### PR TITLE
Add example using Pywebview

### DIFF
--- a/examples/pywebview/README.md
+++ b/examples/pywebview/README.md
@@ -1,0 +1,12 @@
+This is an example [Pywebview](https://github.com/r0x0r/pywebview) application
+built using Pynsist.
+
+First, run `./download.sh` to fetch and unpack the necessary Windows libraries.
+Then build with:
+
+    pynsist installer.cfg
+
+At present, the user must separately install the MS Visual C++ 2010 redistributable,
+because pywin32 is compiled using that.
+
+http://www.microsoft.com/en-us/download/details.aspx?id=14632

--- a/examples/pywebview/download.sh
+++ b/examples/pywebview/download.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Download pywin32 for Python 3.5, 64 bit
+set -e
+
+if [ ! -f pywin32.exe]; then
+  wget -O pywin32.exe wget https://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py3.5.exe
+fi
+
+# Comtypes (this is actually pure Python, but it's Windows only,
+# so it's easiest to get it like this)
+if [ ! -f comtypes.zip]; then
+  wget -O comtypes.zip https://github.com/enthought/comtypes/archive/1.1.2.zip
+fi
+
+rm -rf pynsist_pkgs
+mkdir pynsist_pkgs
+
+# Unpack pywin32
+td=$(mktemp -d)
+unzip pywin32.exe -d $td || true  # Suppress some warning/error unzipping
+echo "Copying pywin32 files into pynsist_pkgs/"
+cp --recursive $td/PLATLIB/* pynsist_pkgs/
+rm -r $td
+
+# Unpack comtypes
+td=$(mktemp -d)
+unzip comtypes.zip -d $td
+# If comtypes.gen exists, it gets stuck trying to write there; if not, it
+# falls back to %APPDATA%.
+rm -r $td/comtypes-*/comtypes/gen/
+echo "Running 2to3 on comtypes"
+2to3 -wn --no-diffs $td/comtypes-*/comtypes/
+echo "Copying comtypes files into pynsist_pkgs/"
+cp --recursive $td/comtypes-*/comtypes pynsist_pkgs/
+rm -r $td

--- a/examples/pywebview/download.sh
+++ b/examples/pywebview/download.sh
@@ -2,14 +2,14 @@
 # Download pywin32 for Python 3.5, 64 bit
 set -e
 
-if [ ! -f pywin32.exe]; then
-  wget -O pywin32.exe wget https://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py3.5.exe
+if [ ! -f pywin32.exe ]; then
+  wget -O pywin32.exe https://sourceforge.net/projects/pywin32/files/pywin32/Build%20220/pywin32-220.win-amd64-py3.5.exe
 fi
 
 # Comtypes (this is actually pure Python, but it's Windows only,
 # so it's easiest to get it like this)
-if [ ! -f comtypes.zip]; then
-  wget -O comtypes.zip https://github.com/enthought/comtypes/archive/1.1.2.zip
+if [ ! -f comtypes.zip ]; then
+  wget -O comtypes.zip https://github.com/enthought/comtypes/archive/1.1.3.zip
 fi
 
 rm -rf pynsist_pkgs

--- a/examples/pywebview/installer.cfg
+++ b/examples/pywebview/installer.cfg
@@ -1,0 +1,19 @@
+[Application]
+name=Pywebview example
+version=1.0
+entry_point=simple_browser:main
+# Yuck, pywin32 stores modules in odd places, so we need this to get them loaded
+# correctly
+extra_preamble=pywin32_paths.py
+
+[Python]
+version=3.5.1
+bitness=64
+format=bundled
+
+[Include]
+# pywin32 should also be included here, but it contains many pieces in odd
+# locations, so it's probably not simple. When building from Linux, the
+# download.sh script copies the necessary files in.
+packages=comtypes
+  webview

--- a/examples/pywebview/pywin32_paths.py
+++ b/examples/pywebview/pywin32_paths.py
@@ -1,0 +1,12 @@
+sys.path.extend([
+    os.path.join(pkgdir, 'win32'),
+    os.path.join(pkgdir, 'win32', 'lib'),
+    os.path.join(pkgdir, 'Pythonwin'),
+])
+
+# Preload pywintypes and pythoncom
+pwt = os.path.join(pkgdir, 'pywin32_system32', 'pywintypes35.dll')
+pcom = os.path.join(pkgdir, 'pywin32_system32', 'pythoncom35.dll')
+import imp
+imp.load_dynamic('pywintypes', pwt)
+imp.load_dynamic('pythoncom', pcom)

--- a/examples/pywebview/simple_browser.py
+++ b/examples/pywebview/simple_browser.py
@@ -9,7 +9,7 @@ import webview
 
 def main():
     # Create a non-resizable webview window with 800x600 dimensions
-    webview.create_window("Simple browser", "http://www.flowrl.com",
+    webview.create_window("Simple browser", "http://pynsist.readthedocs.io/",
                             width=800, height=600, resizable=False)
 
 if __name__ == '__main__':

--- a/examples/pywebview/simple_browser.py
+++ b/examples/pywebview/simple_browser.py
@@ -1,0 +1,16 @@
+"""
+This example demonstrates how to create a webview window.
+
+Adapted from a pywebview example:
+https://github.com/r0x0r/pywebview/blob/master/examples/simple_browser.py
+"""
+
+import webview
+
+def main():
+    # Create a non-resizable webview window with 800x600 dimensions
+    webview.create_window("Simple browser", "http://www.flowrl.com",
+                            width=800, height=600, resizable=False)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I have got this working, but it's decidedly rough:

- Pywin32 is compiled with an older version of the MSVCR (2010), which the user has to [download separately](http://www.microsoft.com/en-us/download/details.aspx?id=14632) and install.
- The resulting application is *really* slow, practically unusable even on a new laptop. The culprit appears to be something in comtypes which generates code containing `True = 1`, which is a syntax error in Python 3. I think that the error loading this generated code causes it to keep trying to generate it again. When I comment that line out, it runs at a reasonable speed.
- Building on Windows probably won't work, because it relies on the bash script fetching and arranging things. It should be easy enough to translate to Python if anyone wants to do that, though.