### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ people who don't have Python installed.
 
 At present, pynsist requires Python 3.3 or above, or Python 2.7.
 
-For more information, see `the documentation <http://pynsist.readthedocs.org/en/latest/>`_
+For more information, see `the documentation <https://pynsist.readthedocs.io/en/latest/>`_
 and `the examples <https://github.com/takluyver/pynsist/tree/master/examples>`_.
 
 Quickstart

--- a/examples/pyqt4/README.md
+++ b/examples/pyqt4/README.md
@@ -5,7 +5,7 @@ This will download a PyQt Windows installer from Sourceforge, unpack the files
 from it, and copy the necessary ones into pynsist_pkgs where pynsist will
 pick them up.
 
-If you want to use PyQt in a '[bundled format](http://pynsist.readthedocs.org/en/latest/cfgfile.html#bundled-python)'
+If you want to use PyQt in a '[bundled format](https://pynsist.readthedocs.io/en/latest/cfgfile.html#bundled-python)'
 installer with Python 3.5 or later, you'll need to ensure the file `msvcp140.dll`
 is included. If you have a Visual Studio installation, you can find it in there;
 otherwise download the [Visual C++ Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145).

--- a/flit.ini
+++ b/flit.ini
@@ -3,7 +3,7 @@ module = nsist
 author = Thomas Kluyver
 author-email = thomas@kluyver.me.uk
 dist-name = pynsist
-home-page = http://pynsist.readthedocs.org/en/latest/
+home-page = https://pynsist.readthedocs.io/en/latest/
 description-file = README.rst
 requires = requests
     requests_download


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.