### PR TITLE
Add DisplayVersion to the Uninstall info

### DIFF
--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -107,6 +107,8 @@ Section "!${PRODUCT_NAME}" sec_app
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
                      "Publisher" "[[ib.publisher]]"
   [% endif %]
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+                   "DisplayVersion" "${PRODUCT_VERSION}"
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
                    "NoModify" 1
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \


### PR DESCRIPTION
As the version is required and `${PRODUCT_VERSION}` is already set, it seems like a no-brainer to add the version info :) 