### PR TITLE
Combine packages when package already exists

### DIFF
--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -1,3 +1,4 @@
+import distutils.dir_util
 from distutils.version import LooseVersion
 import errno
 import hashlib
@@ -181,7 +182,9 @@ def extract_wheel(whl_file, target_dir):
     for p in td.iterdir():
         if p.suffix not in {'.data', '.dist-info'}:
             if p.is_dir():
-                shutil.copytree(str(p), str(target / p.name))
+                # If the dst directory already exists, this will combine them.
+                # shutil.copytree will not combine them.
+                distutils.dir_util.copy_tree(str(p), str(target / p.name))
             else:
                 shutil.copy2(str(p), str(target))
             copied_something = True


### PR DESCRIPTION
Fixes https://github.com/takluyver/pynsist/issues/103

Uses https://docs.python.org/3/distutils/apiref.html#distutils.dir_util.copy_tree which will overwrite any existing files.

