### PR TITLE
Allowing config values to start with a newline

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -24,6 +24,7 @@ if os.name == 'nt':
 else:
     winreg = None
 
+from .configreader import get_installer_builder_args
 from .commands import prepare_bin_directory
 from .copymodules import copy_modules
 from .nsiswriter import NSISFileWriter
@@ -499,35 +500,6 @@ if __name__ == '__main__':
 
             if not exitcode:
                 logger.info('Installer written to %s', pjoin(self.build_dir, self.installer_name))
-
-
-def get_installer_builder_args(config):
-    def get_boolean(s):
-        if s.lower() in ('1', 'yes', 'true', 'on'):
-            return True
-        if s.lower() in ('0', 'no', 'false', 'off'):
-            return False
-        raise ValueError('ValueError: Not a boolean: {}'.format(s))
-
-    appcfg = config['Application']
-    args = {}
-    args['appname'] = appcfg['name'].strip()
-    args['version'] = appcfg['version'].strip()
-    args['publisher'] = appcfg['publisher'].strip() if 'publisher' in appcfg else None
-    args['icon'] = appcfg.get('icon', DEFAULT_ICON).strip()
-    args['packages'] = config.get('Include', 'packages', fallback='').strip().splitlines()
-    args['pypi_wheel_reqs'] = config.get('Include', 'pypi_wheels', fallback='').strip().splitlines()
-    args['extra_files'] = configreader.read_extra_files(config)
-    args['py_version'] = config.get('Python', 'version', fallback=DEFAULT_PY_VERSION).strip()
-    args['py_bitness'] = config.getint('Python', 'bitness', fallback=DEFAULT_BITNESS)
-    args['py_format'] = config.get('Python', 'format').strip() if 'format' in config['Python'] else None
-    inc_msvcrt = config.get('Python', 'include_msvcrt', fallback='True')
-    args['inc_msvcrt'] = get_boolean(inc_msvcrt.strip())
-    args['build_dir'] = config.get('Build', 'directory', fallback=DEFAULT_BUILD_DIR).strip()
-    args['installer_name'] = config.get('Build', 'installer_name') if 'installer_name' in config['Build'] else None
-    args['nsi_template'] = config.get('Build', 'nsi_template').strip() if 'nsi_template' in config['Build'] else None
-    args['exclude'] = config.get('Include', 'exclude', fallback='').strip().splitlines()
-    return args
 
 def main(argv=None):
     """Make an installer from the command line.

--- a/nsist/tests/data_files/valid_config_value_newline.cfg
+++ b/nsist/tests/data_files/valid_config_value_newline.cfg
@@ -1,0 +1,41 @@
+[Application]
+name=
+    My App
+version=
+    1.0
+publisher=
+    Test
+entry_point=
+    myapp:main
+icon=
+    myapp.ico
+
+[Python]
+version=
+    3.6.0
+bitness=
+    64
+format=
+    bundled
+include_msvcrt =
+    True
+
+[Build]
+directory=
+    build/
+nsi_template=
+    template.nsi
+
+[Include]
+packages =
+    requests
+    bs4
+pypi_wheels=
+    html5lib
+exclude=
+    something
+
+# Other files and folders that should be installed
+files =
+    LICENSE
+    data_files/

--- a/nsist/tests/test_configuration_validator.py
+++ b/nsist/tests/test_configuration_validator.py
@@ -4,7 +4,6 @@ import os
 from nose.tools import *
 
 from .. import configreader
-from .. import get_installer_builder_args
 
 
 DATA_FILES = os.path.join(os.path.dirname(__file__), 'data_files')
@@ -12,10 +11,7 @@ DATA_FILES = os.path.join(os.path.dirname(__file__), 'data_files')
 def test_valid_config():
     configfile = os.path.join(DATA_FILES, 'valid_config.cfg')
     config = configreader.read_and_validate(configfile)
-    print(config['Application'])
-    print('Application' in config)
-    print(config.has_section('Application'))
-    # assert False
+    assert config.has_section('Application')
 
 def test_valid_config_with_shortcut():
     configfile = os.path.join(DATA_FILES, 'valid_config_with_shortcut.cfg')
@@ -49,7 +45,7 @@ def test_valid_config_with_values_starting_on_new_line():
     assert config.get('Include', 'exclude') == '\nsomething'
     assert config.get('Include', 'files') == '\nLICENSE\ndata_files/'
 
-    args = get_installer_builder_args(config)
+    args = configreader.get_installer_builder_args(config)
     assert args['appname'] == 'My App'
     assert args['version'] == '1.0'
     assert args['publisher'] == 'Test'

--- a/nsist/tests/test_configuration_validator.py
+++ b/nsist/tests/test_configuration_validator.py
@@ -1,17 +1,75 @@
-from nose.tools import *
-import os
-from .. import configreader
 import configparser
+import os
+
+from nose.tools import *
+
+from .. import configreader
+from .. import get_installer_builder_args
+
 
 DATA_FILES = os.path.join(os.path.dirname(__file__), 'data_files')
 
 def test_valid_config():
     configfile = os.path.join(DATA_FILES, 'valid_config.cfg')
-    configreader.read_and_validate(configfile)
+    config = configreader.read_and_validate(configfile)
+    print(config['Application'])
+    print('Application' in config)
+    print(config.has_section('Application'))
+    # assert False
 
 def test_valid_config_with_shortcut():
     configfile = os.path.join(DATA_FILES, 'valid_config_with_shortcut.cfg')
-    configreader.read_and_validate(configfile)
+    config = configreader.read_and_validate(configfile)
+
+def test_valid_config_with_values_starting_on_new_line():
+    configfile = os.path.join(DATA_FILES, 'valid_config_value_newline.cfg')
+    config = configreader.read_and_validate(configfile)
+    sections = ('Application', 'Python', 'Include', 'Build')
+    assert len(config.sections()) == len(sections)
+    for section in sections:
+        assert section in config
+        assert config.has_section(section)
+
+    assert config.get('Application', 'name') == '\nMy App'
+    assert config.get('Application', 'version') == '\n1.0'
+    assert config.get('Application', 'publisher') == '\nTest'
+    assert config.get('Application', 'entry_point') == '\nmyapp:main'
+    assert config.get('Application', 'icon') == '\nmyapp.ico'
+
+    assert config.get('Python', 'version') == '\n3.6.0'
+    assert config.get('Python', 'bitness') == '\n64'
+    assert config.get('Python', 'format') == '\nbundled'
+    assert config.get('Python', 'include_msvcrt') == '\nTrue'
+
+    assert config.get('Build', 'directory') == '\nbuild/'
+    assert config.get('Build', 'nsi_template') == '\ntemplate.nsi'
+
+    assert config.get('Include', 'packages') == '\nrequests\nbs4'
+    assert config.get('Include', 'pypi_wheels') == '\nhtml5lib'
+    assert config.get('Include', 'exclude') == '\nsomething'
+    assert config.get('Include', 'files') == '\nLICENSE\ndata_files/'
+
+    args = get_installer_builder_args(config)
+    assert args['appname'] == 'My App'
+    assert args['version'] == '1.0'
+    assert args['publisher'] == 'Test'
+    # assert args['entry_point'] == '\nmyapp:main'
+    assert args['icon'] == 'myapp.ico'
+
+    assert args['py_version'] == '3.6.0'
+    assert args['py_bitness'] == 64
+    assert args['py_format'] == 'bundled'
+    assert args['inc_msvcrt'] == True
+
+    assert args['build_dir'] == 'build/'
+    assert args['nsi_template'] == 'template.nsi'
+
+    assert args['packages'] == ['requests', 'bs4']
+    assert args['pypi_wheel_reqs'] == ['html5lib']
+    assert args['exclude'] == ['something']
+    assert args['extra_files'] == [('', '$INSTDIR'),
+                                    ('LICENSE', '$INSTDIR'),
+                                    ('data_files/', '$INSTDIR')]
 
 @raises(configreader.InvalidConfig)
 def test_invalid_config_keys():


### PR DESCRIPTION
Fixes https://github.com/takluyver/pynsist/issues/112

If you only want to support starting with a newline for `packages`, `pypi_wheels` and `exclude` you just need to add `.strip()` before `.splitlines()` here.

https://github.com/takluyver/pynsist/blob/9cd4cd73e04d52b6b22353dce7d2e3bed9fd8f7f/nsist/__init__.py#L543-L544

