### PR TITLE
Delete existing module folder before replacing with new copy

### DIFF
--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -134,6 +134,8 @@ if not PY2:
                     else:
                         # Don't use our exclude callback if we don't need to,
                         # as it slows things down.
+                        if os.path.exists(dest):
+                            shutil.rmtree(dest)
                         shutil.copytree(
                             pkgdir, dest,
                             ignore=shutil.ignore_patterns('*.pyc')


### PR DESCRIPTION
When re-running pynsist on a project, say after adjusting pynsist config file or updates to the project, I get errors as it tries to assemble the modules folder due to it already existing.

This pull request simply deletes existing folders before trying to overwrite them with shutil.copytree() 