### PR TITLE
Multi pkg example

### DIFF
--- a/examples/multi_pkg_ex/README.md
+++ b/examples/multi_pkg_ex/README.md
@@ -1,0 +1,24 @@
+## Installing `plotly, pandas, sqlalchemy, scipy, numpy` and `matplotlib` with bundled `Python (3.6)` using `pynsist`. 
+
+##### Short Overview:
+
+Packaging these libraries can be tricky because they each require an number of `.dll` files to work. Rather than manually specifying each DLL required, here's a simple way to package these libraries without too much hassle. 
+
+1. `matplotlib` - build it from wheels, under the `pypi-wheels` section of `installer.cfg`. Also, as mentioned in other examples, `matplotlib` additionally requires the `six, pyparsing` and `dateutil` libraries to be manually specified in `installer.cfg`
+
+2. `numpy/scipy` - Packaging these on Windows is a little involved due to `numpy's` reliance on Intel's proprietary `MKL` libraries, and `scipy's` reliance on a few DLLs. The solution is as follows:
+    1) Go to http://www.lfd.uci.edu/~gohlke/pythonlibs/, and download the pre-compiled numpy/scipy binaries. You will notice that the `numpy` binaries are specified as `numpy + mkl`, which is a good thing. 
+    2) Navigate to the directory in which the `.whl` files were downloaded. Change the `.whl` extension to `.zip`.
+    3) Extract both zipped files directly into the same directory containing `installer.cfg`
+    4) In `installer.cfg`, include the following lines. A full example can be found in the `installer.cfg` file associated with this writeup. 
+        - `numpy` > `$INSTDIR\pkgs`
+        - `numpy-1.13.1+mkl.data > $InSTDIR\pkgs`
+        - `numpy-1.13.1+mkl.dist-info > $INSTDIR\pkgs`
+	    - `scipy > $INSTDIR\pkgs`
+	    - `scipy-0.19.1.dist-info > $INSTDIR\pkgs`
+
+3. `plotly`: can be specified under the `package` section, and requires `pprint`, `pkg_resources`, `requests` and `decorator` as additional dependencies.
+
+4. `pandas`: can be specified under the `package` section, and requires `pytz, six, setuptools` and `dateutils` as additional dependencies.
+
+5. `sqlalchemy`: can be specified under the `package` section, and requires `psycopg2` as an additional dependency if one is connecting to a PostgreSQL server. `psycopg2` should be specified under the `pypi-wheels` section to avoid `DLL`-based `ImportErrors`.

--- a/examples/multi_pkg_ex/installer.cfg
+++ b/examples/multi_pkg_ex/installer.cfg
@@ -1,0 +1,35 @@
+[Application]
+name=myapp
+version=1.0
+entry_point=myapp:main
+
+[Python]
+version=3.6.2
+
+[Include]
+packages=pandas
+	tkinter
+	_tkinter
+	cycler
+	six
+	dateutil
+	pyparsing
+	sqlalchemy
+	plotly
+	datetime
+	pprint
+	pytz
+	setuptools
+	requests
+	pkg_resources
+	decorator
+
+pypi_wheels: matplotlib==2.0.2
+	psycopg2==2.7.1
+
+
+files = numpy > $INSTDIR\pkgs
+	numpy-1.13.1+mkl.data > $INSTDIR\pkgs
+	numpy-1.13.1+mkl.dist-info > $INSTDIR\pkgs
+	scipy > $INSTDIR\pkgs
+	scipy-0.19.1.dist-info > $INSTDIR\pkgs

--- a/examples/multi_pkg_ex/installer.cfg
+++ b/examples/multi_pkg_ex/installer.cfg
@@ -8,15 +8,12 @@ version=3.6.2
 
 [Include]
 packages=pandas
-	tkinter
-	_tkinter
 	cycler
 	six
 	dateutil
 	pyparsing
 	sqlalchemy
 	plotly
-	datetime
 	pprint
 	pytz
 	setuptools

--- a/examples/multi_pkg_ex/myapp.py
+++ b/examples/multi_pkg_ex/myapp.py
@@ -1,0 +1,48 @@
+import matplotlib.pyplot as plt 
+import pandas as pd 
+from sqlalchemy import create_engine
+import plotly.plotly as py  
+import plotly.graph_objs as go 
+import numpy as np 
+from scipy.interpolate import interp1d
+
+# set up plotly credentials for publishing purposes. 
+import plotly
+plotly.tools.set_credentials_file(username='test_user', api_key='123456')
+
+
+# Note: This file does not actually execute. It is just an example file to show
+# what an application containing these components could look like. 
+
+def main():
+    # connect to a database using SQLAlchemy.
+    username, password = 'testuser', 'testpassword'
+    engine = create_engine('postgresql://' + username + ':' + password + 'database_url')
+    connection = engine.connect() 
+    query = "user-defined-query"
+
+    # pandas
+    df = pd.read_sql(query, connection)
+    x1 = df.col1.values 
+    x2 = df.col2.values 
+
+    # numpy 
+    x1[np.isnan(x1)] = 0 
+    x2[np.isnan(x2)] = 0 
+
+    # scipy 
+    f1 = interp1d(x1, x2, fill_value='extrapolate')
+
+    # matplotlib
+    plt.scatter(x1.values, x2.values, 'mpl_scatter')
+    plt.plot(x1.values, f1(x1.values), 'scipy interpolation')
+    plt.show()
+
+    # create a few sample graph objects. 
+    trace = go.Scatter(
+        x=x1,
+        y=x2,
+        name='test_plot')
+
+    data = [trace]
+    py.plot(data, filename='plotly_basic_scatter')


### PR DESCRIPTION
As discussed, here's a small example on an application that uses  `sqlalchemy` and `plotly`.

- Added in the steps involving extracting the pre-compiled `scipy/numpy` binaries from Christoph Gohlke's website because I ran into `DLL`-related import errors with these packages. Building these packages from wheels didn't work, and this was the only workaround that I was able to find. 

- I also recommended building `matplotlib` from wheels to avoid `DLL`-based import errors. 

- Also specified dependencies for `pandas`, `plotly` and `sqlalchemy`. 

Hope this helps.