### PR TITLE
Add pkgs to *._pth files.

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -201,7 +201,9 @@ class InstallerBuilder(object):
             z.extractall(python_dir)
 
         # Manipulate any *._pth files so the default paths AND pkgs directory
-        # ends up in sys.path.
+        # ends up in sys.path. Please see:
+        # https://docs.python.org/3/using/windows.html#finding-modules
+        # for more information.
         pth_files = [f for f in os.listdir(python_dir)
                      if os.path.isfile(pjoin(python_dir, f))
                      and f.endswith('._pth')]

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -178,6 +178,9 @@ class InstallerBuilder(object):
         """Fetch the embeddable Windows build for the specified Python version
 
         It will be unpacked into the build directory.
+
+        In addition, any *._pth files found therein will have the pkgs path
+        appended to them.
         """
         url, filename = self._python_download_url_filename()
         cache_file = get_cache_dir(ensure_existence=True) / filename
@@ -196,6 +199,15 @@ class InstallerBuilder(object):
 
         with zipfile.ZipFile(str(cache_file)) as z:
             z.extractall(python_dir)
+
+        # Manipulate any *._pth files so the default paths AND pkgs directory
+        # ends up in sys.path.
+        pth_files = [f for f in os.listdir(python_dir)
+                     if os.path.isfile(pjoin(python_dir, f))
+                     and f.endswith('._pth')]
+        for pth in pth_files:
+            with open(pjoin(python_dir, pth), 'a+b') as f:
+                f.write(b'\r\n..\\pkgs\r\n')
 
         self.install_dirs.append(('Python', '$INSTDIR'))
 


### PR DESCRIPTION
When launching new child processes from an application packaged by pynsist the `pkgs` directory is **NOT** in `sys.path` causing import errors in the child process. The rule about `._pth` files applies (from the CPython source here: https://github.com/python/cpython/blob/3.6/PC/getpathp.c#L49):

`In the presence of this ._pth file, no other paths are added to the
search path, the registry finder is not enabled, site.py is not imported
and isolated mode is enabled. The site package can be enabled by
including a line reading "import site"; no other imports are recognized.
Any invalid entry (other than directories that do not exist) will result
in immediate termination of the program.`

This PR fixes the problem by ensuring the `pkgs` directory is referenced in the `._pth` files that may be installed in the `Python` directory.