### PR TITLE
Add option to execute commands after installation

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -89,6 +89,7 @@ class InstallerBuilder(object):
     :param str build_dir: Directory to run the build in
     :param str installer_name: Filename of the installer to produce
     :param str nsi_template: Path to a template NSI file to use
+    :param list install_commands: Commands to be run after installation
     """
     def __init__(self, appname, version, shortcuts, *, publisher=None,
                 icon=DEFAULT_ICON, packages=None, extra_files=None,
@@ -96,7 +97,7 @@ class InstallerBuilder(object):
                 py_format='bundled', inc_msvcrt=True, build_dir=DEFAULT_BUILD_DIR,
                 installer_name=None, nsi_template=None,
                 exclude=None, pypi_wheel_reqs=None, extra_wheel_sources=None,
-                commands=None, license_file=None):
+                commands=None, license_file=None, install_commands=None):
         self.appname = appname
         self.version = version
         self.publisher = publisher
@@ -109,6 +110,7 @@ class InstallerBuilder(object):
         self.extra_wheel_sources = extra_wheel_sources or []
         self.commands = commands or {}
         self.license_file = license_file
+        self.install_commands = install_commands
 
         # Python options
         self.py_version = py_version

--- a/nsist/configreader.py
+++ b/nsist/configreader.py
@@ -76,6 +76,7 @@ CONFIG_VALIDATORS = {
         ('extra_wheel_sources', False),
         ('files', False),
         ('exclude', False),
+        ('install_commands', False),
     ]),
     'Python': SectionValidator([
         ('version', False),
@@ -235,4 +236,5 @@ def get_installer_builder_args(config):
     args['installer_name'] = config.get('Build', 'installer_name', fallback=None)
     args['nsi_template'] = config.get('Build', 'nsi_template', fallback=None)
     args['exclude'] = config.get('Include', 'exclude', fallback='').strip().splitlines()
+    args['install_commands'] = config.get('Include', 'install_commands', fallback='').strip().splitlines()
     return args

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -135,6 +135,11 @@ Section "!${PRODUCT_NAME}" sec_app
   WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
                    "NoRepair" 1
 
+  [% for command in ib.install_commands %]
+    SetOutPath $INSTDIR
+    nsExec::ExecToLog '[[ command ]]'
+  [% endfor %]
+
   ; Check if we need to reboot
   IfRebootFlag 0 noreboot
     MessageBox MB_YESNO "A reboot is required to finish the installation. Do you wish to reboot now?" \


### PR DESCRIPTION
Hi, thanks for your work.

This is a suggestion for a new configuration field. The idea is to allow running commands after the installation is done. We're using it to install a service using [nssm](https://nssm.cc/).

An example of the new option in use:
```
[Include]
files = service.exe
install_commands = "$INSTDIR\nssm.exe" install myservice "$INSTDIR\service.exe"
                   "$INSTDIR\nssm.exe" set myservice AppDirectory "$INSTDIR"
```

If you're interested but have some suggestions, I'd be happy to take them into account!