### PR TITLE
pynsist: make the "exclude" option work with pypi_wheels

### DIFF
--- a/doc/cfgfile.rst
+++ b/doc/cfgfile.rst
@@ -271,7 +271,7 @@ the line with the key:
      shell.
    * If you want to exclude whole subfolders, do *not* put a path separator 
      (e.g. ``/``) at their end.
-   * The exclude patterns are only applied to packages and to directories
+   * The exclude patterns are applied to packages, pypi wheels, and directories
      specified using the ``files`` option. If your ``exclude`` option directly 
      contradicts your ``files`` or ``packages`` option, the files in question
      will be included (you can not exclude a full package/extra directory

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -349,7 +349,8 @@ if __name__ == '__main__':
         # 2. Wheels from PyPI
         fetch_pypi_wheels(self.pypi_wheel_reqs, build_pkg_dir,
                           py_version=self.py_version, bitness=self.py_bitness,
-                          extra_sources=self.extra_wheel_sources)
+                          extra_sources=self.extra_wheel_sources,
+                          exclude=self.exclude)
 
         # 3. Copy importable modules
         copy_modules(self.packages, build_pkg_dir,


### PR DESCRIPTION
Teach extract_wheel() to handle exclude patterns.  This allows us to
filter paths out of wheels, which can be helpful in many situations.