### PR TITLE
nsist: use "/" when comparing fnmatch patterns

### DIFF
--- a/doc/cfgfile.rst
+++ b/doc/cfgfile.rst
@@ -276,6 +276,10 @@ the line with the key:
      contradicts your ``files`` or ``packages`` option, the files in question
      will be included (you can not exclude a full package/extra directory
      or a single file listed in ``files``).
+   * Exclude patterns are applied uniformly across platforms and can use
+     either Unix-style forward-slash (`/`), or Windows-style back-slash (`\`)
+     path separators.  Exclude patterns are normalized so that patterns
+     written on Unix will work on Windows, and vice-versa.
 
    Example:
 

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -24,7 +24,7 @@ from .commands import prepare_bin_directory
 from .copymodules import copy_modules
 from .nsiswriter import NSISFileWriter
 from .pypi import fetch_pypi_wheels
-from .util import download, text_types, get_cache_dir
+from .util import download, text_types, get_cache_dir, normalize_path
 
 __version__ = '2.1'
 
@@ -103,7 +103,7 @@ class InstallerBuilder(object):
         self.shortcuts = shortcuts
         self.icon = icon
         self.packages = packages or []
-        self.exclude = [os.path.normpath(p) for p in (exclude or [])]
+        self.exclude = [normalize_path(p) for p in (exclude or [])]
         self.extra_files = extra_files or []
         self.pypi_wheel_reqs = pypi_wheel_reqs or []
         self.extra_wheel_sources = extra_wheel_sources or []

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -9,6 +9,8 @@ import zipfile, zipimport
 import fnmatch
 from functools import partial
 
+from .util import normalize_path
+
 pjoin = os.path.join
 
 PY2 = sys.version_info[0] == 2
@@ -77,8 +79,7 @@ def copytree_ignore_callback(excludes, pkgdir, modname, directory, files):
     # Filter by file names relative to the build directory
     reldir = os.path.relpath(directory, pkgdir)
     target = os.path.join('pkgs', modname, reldir)
-    files = [os.path.normpath(os.path.join(target, fname)) for fname in files]
-
+    files = [normalize_path(os.path.join(target, fname)) for fname in files]
     # Execute all patterns
     for pattern in excludes + ['*.pyc']:
         ignored.update([

--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -15,7 +15,7 @@ import zipfile
 import yarg
 from requests_download import download, HashTracker
 
-from .util import get_cache_dir
+from .util import get_cache_dir, normalize_path
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +261,7 @@ def fetch_pypi_wheels(requirements, target_dir, py_version, bitness,
 
 def is_excluded(path, exclude):
     """Return True if path matches an exclude pattern"""
+    path = normalize_path(path)
     for pattern in (exclude or ()):
         if fnmatch.fnmatch(path, pattern):
             return True

--- a/nsist/util.py
+++ b/nsist/util.py
@@ -64,3 +64,8 @@ def get_cache_dir(ensure_existence=False):
                 raise
 
     return p
+
+
+def normalize_path(path):
+    """Normalize paths to contain "/" only"""
+    return os.path.normpath(path).replace('\\', '/')


### PR DESCRIPTION
Canonicalize paths to their Unix representation when comparing fnmatch
patterns.  This makes patterns work across platforms, and
simplifies usage by providing a consistent interface to the
exclude patterns.
    
Closes #39
