### PR TITLE
nsist: provide an "installdir" variable for consistency

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -231,6 +231,7 @@ class InstallerBuilder(object):
     SCRIPT_TEMPLATE = """#!python{qualifier}
 import sys, os
 scriptdir, script = os.path.split(__file__)
+installdir = scriptdir  # for compatibility with commands
 pkgdir = os.path.join(scriptdir, 'pkgs')
 sys.path.insert(0, pkgdir)
 os.environ['PYTHONPATH'] = pkgdir + os.pathsep + os.environ.get('PYTHONPATH', '')


### PR DESCRIPTION
The "commands" template calls the install directory
"installdir", but entry points call it "scriptdir".

Add an "installdir" variable to entry points for compatibility.  This
increases the chances of being able to reuse an "extra_preamble" script
across commands and entry points.