### PR TITLE
Modified pjoin command to ensure path is formatted correctly

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -28,7 +28,6 @@ from .util import download, text_types, get_cache_dir, normalize_path
 
 __version__ = '2.1'
 
-pjoin = os.path.join
 logger = logging.getLogger(__name__)
 
 _PKGDIR = os.path.abspath(os.path.dirname(__file__))
@@ -39,6 +38,10 @@ if os.name == 'nt' and sys.maxsize == (2**63)-1:
     DEFAULT_BITNESS = 64
 else:
     DEFAULT_BITNESS = 32
+
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    return newPath
 
 def find_makensis_win():
     """Locate makensis.exe on Windows by querying the registry"""

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -11,13 +11,15 @@ from functools import partial
 
 from .util import normalize_path
 
-pjoin = os.path.join
-
 PY2 = sys.version_info[0] == 2
 running_python  = '.'.join(str(x) for x in sys.version_info[:2])
 
 class ExtensionModuleMismatch(ImportError):
     pass
+
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    return newPath
 
 extensionmod_errmsg = """Found an extension module that will not be usable on %s:
 %s

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -11,6 +11,9 @@ _PKGDIR = os.path.abspath(os.path.dirname(__file__))
 
 PY2 = sys.version_info[0] == 2
 
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", ntpath.join(*args, **kwargs))
+    return newPath
 
 class NSISFileWriter(object):
     """Write an .nsi script file by filling in a template.
@@ -54,7 +57,7 @@ class NSISFileWriter(object):
             'grouped_files': grouped_files,
             'icon': os.path.basename(installerbuilder.icon),
             'arch_tag': '.amd64' if (installerbuilder.py_bitness==64) else '',
-            'pjoin': ntpath.join,
+            'pjoin': pjoin,
             'single_shortcut': len(installerbuilder.shortcuts) == 1,
             'pynsist_pkg_dir': _PKGDIR,
             'has_commands': len(installerbuilder.commands) > 0,


### PR DESCRIPTION
This will handle user paths that contain /, \, and \\.
Included files like "$OUTDIR/docs/code/subfolder" will not collapse into $OUTDIR/docscodesubfolder either.