### PR TITLE
Nest installers

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -30,6 +30,14 @@ __version__ = '2.1'
 
 logger = logging.getLogger(__name__)
 
+def pjoin(*args, **kwargs):
+    newPath = ensurePathFormat(os.path.join(*args, **kwargs))
+    return newPath
+
+def ensurePathFormat(oldPath):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", oldPath)
+    return newPath
+
 _PKGDIR = os.path.abspath(os.path.dirname(__file__))
 DEFAULT_PY_VERSION = '3.6.3'
 DEFAULT_BUILD_DIR = pjoin('build', 'nsis')

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -28,7 +28,6 @@ from .util import download, text_types, get_cache_dir, normalize_path
 
 __version__ = '2.1'
 
-pjoin = os.path.join
 logger = logging.getLogger(__name__)
 
 _PKGDIR = os.path.abspath(os.path.dirname(__file__))
@@ -39,6 +38,10 @@ if os.name == 'nt' and sys.maxsize == (2**63)-1:
     DEFAULT_BITNESS = 64
 else:
     DEFAULT_BITNESS = 32
+
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    return newPath
 
 def find_makensis_win():
     """Locate makensis.exe on Windows by querying the registry"""

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -18,7 +18,11 @@ class ExtensionModuleMismatch(ImportError):
     pass
 
 def pjoin(*args, **kwargs):
-    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    newPath = ensurePathFormat(os.path.join(*args, **kwargs))
+    return newPath
+
+def ensurePathFormat(oldPath):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", oldPath)
     return newPath
 
 extensionmod_errmsg = """Found an extension module that will not be usable on %s:

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -11,13 +11,15 @@ from functools import partial
 
 from .util import normalize_path
 
-pjoin = os.path.join
-
 PY2 = sys.version_info[0] == 2
 running_python  = '.'.join(str(x) for x in sys.version_info[:2])
 
 class ExtensionModuleMismatch(ImportError):
     pass
+
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    return newPath
 
 extensionmod_errmsg = """Found an extension module that will not be usable on %s:
 %s

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -68,6 +68,7 @@ class NSISFileWriter(object):
             'has_commands': len(installerbuilder.commands) > 0,
             'has_prereq': len(installerbuilder.extra_installers) > 0,
             'gen_prereq': installerbuilder.apply_extra_installers,
+            'has_checkRegistry': installerbuilder.has_checkRegistry,
             'has_checkDirContains': installerbuilder.has_checkDirContains,
             'has_checkDirStartsWith': installerbuilder.has_checkDirStartsWith,
             'has_checkDirEndsWith': installerbuilder.has_checkDirEndsWith,

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -68,6 +68,10 @@ class NSISFileWriter(object):
             'has_commands': len(installerbuilder.commands) > 0,
             'has_prereq': len(installerbuilder.extra_installers) > 0,
             'gen_prereq': installerbuilder.apply_extra_installers,
+            'has_checkDirContains': installerbuilder.has_checkDirContains,
+            'has_checkDirStartsWith': installerbuilder.has_checkDirStartsWith,
+            'has_checkDirEndsWith': installerbuilder.has_checkDirEndsWith,
+            'has_checkDirLike': installerbuilder.has_checkDirLike,
             'python': '"$INSTDIR\\Python\\python"',
             'license_file': license_file,
         }

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -11,6 +11,9 @@ _PKGDIR = os.path.abspath(os.path.dirname(__file__))
 
 PY2 = sys.version_info[0] == 2
 
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", ntpath.join(*args, **kwargs))
+    return newPath
 
 class NSISFileWriter(object):
     """Write an .nsi script file by filling in a template.
@@ -54,7 +57,7 @@ class NSISFileWriter(object):
             'grouped_files': grouped_files,
             'icon': os.path.basename(installerbuilder.icon),
             'arch_tag': '.amd64' if (installerbuilder.py_bitness==64) else '',
-            'pjoin': ntpath.join,
+            'pjoin': pjoin,
             'single_shortcut': len(installerbuilder.shortcuts) == 1,
             'pynsist_pkg_dir': _PKGDIR,
             'has_commands': len(installerbuilder.commands) > 0,

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -12,7 +12,11 @@ _PKGDIR = os.path.abspath(os.path.dirname(__file__))
 PY2 = sys.version_info[0] == 2
 
 def pjoin(*args, **kwargs):
-    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", ntpath.join(*args, **kwargs))
+    newPath = ensurePathFormat(ntpath.join(*args, **kwargs))
+    return newPath
+
+def ensurePathFormat(oldPath):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", oldPath)
     return newPath
 
 class NSISFileWriter(object):
@@ -58,9 +62,12 @@ class NSISFileWriter(object):
             'icon': os.path.basename(installerbuilder.icon),
             'arch_tag': '.amd64' if (installerbuilder.py_bitness==64) else '',
             'pjoin': pjoin,
+            'ensurePathFormat': ensurePathFormat,
             'single_shortcut': len(installerbuilder.shortcuts) == 1,
             'pynsist_pkg_dir': _PKGDIR,
             'has_commands': len(installerbuilder.commands) > 0,
+            'has_prereq': len(installerbuilder.extra_installers) > 0,
+            'gen_prereq': installerbuilder.apply_extra_installers,
             'python': '"$INSTDIR\\Python\\python"',
             'license_file': license_file,
         }

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -71,7 +71,7 @@ Section "!${PRODUCT_NAME}" sec_app
   [% block install_files %]
   ; Install files
   [% for destination, group in grouped_files %]
-    SetOutPath "[[destination]]"
+    SetOutPath "[[ensurePathFormat(destination)]]"
     [% for file in group %]
       File "[[ file ]]"
     [% endfor %]

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -53,6 +53,11 @@ Section -SETTINGS
 SectionEnd
 
 [% block sections %]
+[% if has_prereq %]
+Section -Prerequisites
+  [[gen_prereq()]]
+SectionEnd
+[% endif %]
 
 Section "!${PRODUCT_NAME}" sec_app
   SetRegView [[ib.py_bitness]]
@@ -160,6 +165,11 @@ Section "Uninstall"
     nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" remove "$INSTDIR\bin"'
   [% endif %]
   [% endblock uninstall_commands %]
+
+  ; Remove prerequisites
+  [% if has_prereq %]
+    RMDir /r "$INSTDIR\\Prerequisites"
+  [% endif %]
 
   [% block uninstall_files %]
   ; Uninstall files


### PR DESCRIPTION
Added code for running prerequisite installers for your installer. For example, say you needed to have specific drivers installed for your program to work correctly.
It would be nice if the installer for your program checked to see if those drivers were installed, and if they were not- run the installer to install them.

In the example below, I have a file called `Datalogic_USBCOMInstaller.msi`, which will install the drivers for a barcode scanner.
I pass in the following to `nsist.InstallerBuilder` as the parameter `extra_installers`: `'extra_installers': [('Datalogic_USBCOMInstaller.msi', '', 0, {'not_inRegistry': ('HKLM', 'DRIVERS\\DriverDatabase\\DriverInfFiles\\oem187.inf', 'Active', '')})]`

This will add code to the generated .nsi file which will run the installer `Datalogic_USBCOMInstaller.msi` and wait for it to finish, only if the key `DRIVERS\\DriverDatabase\\DriverInfFiles\\oem187.inf` with the sub-key `Active` is not in the `HKLM` registry.

Multiple conditions can be added by adding keys to the dictionary that is passed in as the 4th element in the tuple. Other installers can be added as more 4-item tuples in the list.

Right now, I have code for:
- Running the extra installer
- Running the extra installer if the conditions are true
- Running the extra installer after a popup message appears and the user clicks 'ok'
- Running the extra installer if the conditions are true and after a popup message appears and the user clicks 'ok'
- Running the extra installer after a popup message appears and the user clicks 'yes' instead of 'no'
- Running the extra installer if the conditions are true and after a popup message appears and the user clicks 'yes' instead of 'no'

The conditions that I have created are:
- `inRegistry`: The given key must be in the given registry
- `not_inRegistry`: The given key must not be in the given registry
- `contains`: The given folder must contain the given file
- `not_contains`: The given folder must not contain the given file

Conditions that I laid the groundwork for, but need more work on the NSIS function that accompanies them:
- `starts_with`: The given folder must contain a file that starts with the given value
- `not_starts_with`: The given folder must not contain a file that starts with the given value
- `ends_with`: The given folder must contain a file that ends with the given value
- `not_ends_with`: The given folder must not contain a file that ends with the given value
- `like`: The given folder must contain a file that contains the given value anywhere in it's filename
- `not_like`: The given folder must not contain a file that contains the given value anywhere in it's filename






