### PR TITLE
Unique build name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pynsist_pkgs/
 
 # This is a big file, so let it sit here after download
 examples/pygi_mpl_numpy/pygi.exe
+__init__.py

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -30,6 +30,14 @@ __version__ = '2.1'
 
 logger = logging.getLogger(__name__)
 
+def pjoin(*args, **kwargs):
+    newPath = ensurePathFormat(os.path.join(*args, **kwargs))
+    return newPath
+
+def ensurePathFormat(oldPath):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", oldPath)
+    return newPath
+
 _PKGDIR = os.path.abspath(os.path.dirname(__file__))
 DEFAULT_PY_VERSION = '3.6.3'
 DEFAULT_BUILD_DIR = pjoin('build', 'nsis')

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -28,7 +28,6 @@ from .util import download, text_types, get_cache_dir, normalize_path
 
 __version__ = '2.1'
 
-pjoin = os.path.join
 logger = logging.getLogger(__name__)
 
 _PKGDIR = os.path.abspath(os.path.dirname(__file__))
@@ -39,6 +38,10 @@ if os.name == 'nt' and sys.maxsize == (2**63)-1:
     DEFAULT_BITNESS = 64
 else:
     DEFAULT_BITNESS = 32
+
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    return newPath
 
 def find_makensis_win():
     """Locate makensis.exe on Windows by querying the registry"""

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -18,7 +18,11 @@ class ExtensionModuleMismatch(ImportError):
     pass
 
 def pjoin(*args, **kwargs):
-    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    newPath = ensurePathFormat(os.path.join(*args, **kwargs))
+    return newPath
+
+def ensurePathFormat(oldPath):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", oldPath)
     return newPath
 
 extensionmod_errmsg = """Found an extension module that will not be usable on %s:

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -11,13 +11,15 @@ from functools import partial
 
 from .util import normalize_path
 
-pjoin = os.path.join
-
 PY2 = sys.version_info[0] == 2
 running_python  = '.'.join(str(x) for x in sys.version_info[:2])
 
 class ExtensionModuleMismatch(ImportError):
     pass
+
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", os.path.join(*args, **kwargs))
+    return newPath
 
 extensionmod_errmsg = """Found an extension module that will not be usable on %s:
 %s

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -68,6 +68,7 @@ class NSISFileWriter(object):
             'has_commands': len(installerbuilder.commands) > 0,
             'has_prereq': len(installerbuilder.extra_installers) > 0,
             'gen_prereq': installerbuilder.apply_extra_installers,
+            'has_checkRegistry': installerbuilder.has_checkRegistry,
             'has_checkDirContains': installerbuilder.has_checkDirContains,
             'has_checkDirStartsWith': installerbuilder.has_checkDirStartsWith,
             'has_checkDirEndsWith': installerbuilder.has_checkDirEndsWith,

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -68,6 +68,10 @@ class NSISFileWriter(object):
             'has_commands': len(installerbuilder.commands) > 0,
             'has_prereq': len(installerbuilder.extra_installers) > 0,
             'gen_prereq': installerbuilder.apply_extra_installers,
+            'has_checkDirContains': installerbuilder.has_checkDirContains,
+            'has_checkDirStartsWith': installerbuilder.has_checkDirStartsWith,
+            'has_checkDirEndsWith': installerbuilder.has_checkDirEndsWith,
+            'has_checkDirLike': installerbuilder.has_checkDirLike,
             'python': '"$INSTDIR\\Python\\python"',
             'license_file': license_file,
         }

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -50,9 +50,16 @@ class NSISFileWriter(object):
         self.installerbuilder = installerbuilder
 
         # Group files by their destination directory
-        grouped_files = [(dest, [x[0] for x in group]) for (dest, group) in
+        grouped_files = [(dest, [(x[0], installerbuilder.extra_files_buildName.get(x, x[0])) for x in group]) for (dest, group) in
             itertools.groupby(self.installerbuilder.install_files, itemgetter(1))
                 ]
+
+        for item in grouped_files:
+            print("@1", item)
+
+        for item in installerbuilder.extra_files_buildName.items():
+            print("@2", item)
+
         license_file = None
         if installerbuilder.license_file:
             license_file = os.path.basename(installerbuilder.license_file)

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -54,12 +54,6 @@ class NSISFileWriter(object):
             itertools.groupby(self.installerbuilder.install_files, itemgetter(1))
                 ]
 
-        for item in grouped_files:
-            print("@1", item)
-
-        for item in installerbuilder.extra_files_buildName.items():
-            print("@2", item)
-
         license_file = None
         if installerbuilder.license_file:
             license_file = os.path.basename(installerbuilder.license_file)

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -11,6 +11,9 @@ _PKGDIR = os.path.abspath(os.path.dirname(__file__))
 
 PY2 = sys.version_info[0] == 2
 
+def pjoin(*args, **kwargs):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", ntpath.join(*args, **kwargs))
+    return newPath
 
 class NSISFileWriter(object):
     """Write an .nsi script file by filling in a template.
@@ -54,7 +57,7 @@ class NSISFileWriter(object):
             'grouped_files': grouped_files,
             'icon': os.path.basename(installerbuilder.icon),
             'arch_tag': '.amd64' if (installerbuilder.py_bitness==64) else '',
-            'pjoin': ntpath.join,
+            'pjoin': pjoin,
             'single_shortcut': len(installerbuilder.shortcuts) == 1,
             'pynsist_pkg_dir': _PKGDIR,
             'has_commands': len(installerbuilder.commands) > 0,

--- a/nsist/nsiswriter.py
+++ b/nsist/nsiswriter.py
@@ -12,7 +12,11 @@ _PKGDIR = os.path.abspath(os.path.dirname(__file__))
 PY2 = sys.version_info[0] == 2
 
 def pjoin(*args, **kwargs):
-    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", ntpath.join(*args, **kwargs))
+    newPath = ensurePathFormat(ntpath.join(*args, **kwargs))
+    return newPath
+
+def ensurePathFormat(oldPath):
+    newPath = re.sub("[/\\\\](?!\\\\)", "\\\\\\\\", oldPath)
     return newPath
 
 class NSISFileWriter(object):
@@ -58,9 +62,12 @@ class NSISFileWriter(object):
             'icon': os.path.basename(installerbuilder.icon),
             'arch_tag': '.amd64' if (installerbuilder.py_bitness==64) else '',
             'pjoin': pjoin,
+            'ensurePathFormat': ensurePathFormat,
             'single_shortcut': len(installerbuilder.shortcuts) == 1,
             'pynsist_pkg_dir': _PKGDIR,
             'has_commands': len(installerbuilder.commands) > 0,
+            'has_prereq': len(installerbuilder.extra_installers) > 0,
+            'gen_prereq': installerbuilder.apply_extra_installers,
             'python': '"$INSTDIR\\Python\\python"',
             'license_file': license_file,
         }

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -71,7 +71,7 @@ Section "!${PRODUCT_NAME}" sec_app
   [% block install_files %]
   ; Install files
   [% for destination, group in grouped_files %]
-    SetOutPath "[[destination]]"
+    SetOutPath "[[ensurePathFormat(destination)]]"
     [% for file in group %]
       File "[[ file ]]"
     [% endfor %]

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -53,6 +53,11 @@ Section -SETTINGS
 SectionEnd
 
 [% block sections %]
+[% if has_prereq %]
+Section -Prerequisites
+  [[gen_prereq()]]
+SectionEnd
+[% endif %]
 
 Section "!${PRODUCT_NAME}" sec_app
   SetRegView [[ib.py_bitness]]
@@ -160,6 +165,11 @@ Section "Uninstall"
     nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" remove "$INSTDIR\bin"'
   [% endif %]
   [% endblock uninstall_commands %]
+
+  ; Remove prerequisites
+  [% if has_prereq %]
+    RMDir /r "$INSTDIR\\Prerequisites"
+  [% endif %]
 
   [% block uninstall_files %]
   ; Uninstall files

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -144,8 +144,8 @@ Section "!${PRODUCT_NAME}" sec_app
   ; Install files
   [% for destination, group in grouped_files %]
     SetOutPath "[[ensurePathFormat(destination)]]"
-    [% for file in group %]
-      File "[[ file ]]"
+    [% for target, file in group %]
+      File /oname=[[ ensurePathFormat(target) ]] "[[ ensurePathFormat(file) ]]" 
     [% endfor %]
   [% endfor %]
   

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -21,7 +21,7 @@ var checkBitness
   StrCpy $root_key "${rootKey}"
   StrCpy $str_dirPath "${subKey}"
   StrCpy $str_filePath "${name}"
-  StrCpy $checkBitness ${bitness}
+  StrCpy $checkBitness "${bitness}"
   Call checkRegistry
 !macroend
 !define checkRegistry '!insertmacro "_checkRegistryConstructor"'


### PR DESCRIPTION
Proposed solution to https://github.com/takluyver/pynsist/issues/156
Just use commits ecbf748 and 7a12c01.

Re:
**Alternate Solution**
Allow the user to rename the files that go into the build directory.
Perhaps something like this:
```
extra_files = [("folder1/__init__.py", "docs\\folder1", "folder1_init.py"), ("folder2/__init__.py", "docs\\folder2", "folder2_init.py")]
```
Which would copy the files in argument 0 and rename them in the build directory as what is in argument 2.
This would then become the following in the .nsi file:
```
 ; Install files
    SetOutPath "$INSTDIR\\docs\\folder1"
      File "folder1_init.py"
    SetOutPath "$INSTDIR\\docs\\folder2"
      File "folder2_init.py"
```