### PR TITLE
Copy package metadata from wheels and from modules

### DIFF
--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -7,7 +7,6 @@ import sys
 import tempfile
 import zipfile, zipimport
 import fnmatch
-import pkg_resources
 from functools import partial
 
 from .util import normalize_path

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -162,7 +162,7 @@ def copy_distribution(modname, target):
         return
 
     egg_info_path = distribution._provider.egg_info
-    if os.path.exists(egg_info_path):
+    if os.path.exists(egg_info_path) and not os.path.exists(dest):
         dest = os.path.join(target, os.path.basename(egg_info_path))
         shutil.copytree(egg_info_path, dest)
 

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import zipfile, zipimport
 import fnmatch
+import pkg_resources
 from functools import partial
 
 from .util import normalize_path
@@ -147,6 +148,23 @@ class ModuleCopier:
 
         elif isinstance(loader, zipimport.zipimporter):
             copy_zipmodule(loader, modname, target)
+
+        copy_distribution(modname, target)
+
+def copy_distribution(modname, target):
+    """Copy the metadata directory of the specified module 
+    to the target directory if exists.
+    """
+    try:
+        distribution = pkg_resources.get_distribution(modname)
+    except pkg_resources.DistributionNotFound:
+        # The package metadata is not available. We skip the process.
+        return
+
+    egg_info_path = distribution._provider.egg_info
+    if os.path.exists(egg_info_path):
+        dest = os.path.join(target, os.path.basename(egg_info_path))
+        shutil.copytree(egg_info_path, dest)
 
 
 def copy_modules(modnames, target, py_version, path=None, exclude=None):

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -149,23 +149,6 @@ class ModuleCopier:
         elif isinstance(loader, zipimport.zipimporter):
             copy_zipmodule(loader, modname, target)
 
-        copy_distribution(modname, target)
-
-def copy_distribution(modname, target):
-    """Copy the metadata directory of the specified module 
-    to the target directory if exists.
-    """
-    try:
-        distribution = pkg_resources.get_distribution(modname)
-    except pkg_resources.DistributionNotFound:
-        # The package metadata is not available. We skip the process.
-        return
-
-    egg_info_path = distribution._provider.egg_info
-    dest = os.path.join(target, os.path.basename(egg_info_path))
-    if os.path.exists(egg_info_path) and not os.path.exists(dest):
-        shutil.copytree(egg_info_path, dest)
-
 
 def copy_modules(modnames, target, py_version, path=None, exclude=None):
     """Copy the specified importable modules to the target directory.

--- a/nsist/copymodules.py
+++ b/nsist/copymodules.py
@@ -162,8 +162,8 @@ def copy_distribution(modname, target):
         return
 
     egg_info_path = distribution._provider.egg_info
+    dest = os.path.join(target, os.path.basename(egg_info_path))
     if os.path.exists(egg_info_path) and not os.path.exists(dest):
-        dest = os.path.join(target, os.path.basename(egg_info_path))
         shutil.copytree(egg_info_path, dest)
 
 

--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -229,7 +229,7 @@ def extract_wheel(whl_file, target_dir, exclude=None):
     target = Path(target_dir)
     copied_something = False
     for p in td.iterdir():
-        if p.suffix not in {'.data', '.dist-info'}:
+        if p.suffix not in {'.data'}:
             if p.is_dir():
                 # If the dst directory already exists, this will combine them.
                 # shutil.copytree will not combine them.

--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -14,6 +14,7 @@ def test_download():
     with TemporaryDirectory() as td:
         extract_wheel(wheel, target_dir=td)
         assert_isfile(pjoin(td, 'astsearch.py'))
+        assert_isfile(pjoin(td, 'astsearch-0.1.2.dist-info', 'METADATA'))
 
 # To exclude this, run:  nosetests -a '!network'
 test_download.network = 1


### PR DESCRIPTION
Following #160.

This PR modify the wheel and modules copy process to ensure that the package metadata (either *.dist-info or *.egg-info) are inserted in the pkgs directory before the installer is built.

This allows to use the plugins discovery mechanism inside a python application installed through the generated NSIS installer.

Regards,
Adrien Ferrand