### PR TITLE
Create a local_wheels parameter to include wheel files matching one or more glob paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ Quickstart
             beautifulsoup4==4.6.0
             html5lib==0.999999999
 
-       # To bundle packages which don't publish wheels, see the docs on the
-       # config file.
+       # To bundle packages which don't publish wheels, or to include directly wheel files
+       # from a directory, see the docs on the config file.
 
        # Other files and folders that should be installed
        files = LICENSE

--- a/doc/cfgfile.rst
+++ b/doc/cfgfile.rst
@@ -223,6 +223,20 @@ the line with the key:
 
    .. versionadded:: 2.0
 
+.. describe:: local_wheels (optional)
+
+   One or more glob paths that matche one or more wheel files located on the
+   local filesystem. All matching wheel files will be included in the installer.
+   For instance ``wheels\*.whl`` will include all wheel files from the relative
+   folder ``wheels``. 
+   
+   Any included wheel corresponding to the same distribution
+   of a wheel specified in ``pypi_wheels`` will raise an error.
+
+   Relative glob paths are from the directory containing the config file.
+
+   .. versionadded:: 2.2
+
 .. describe:: packages (optional)
 
    A list of importable package and module names to include in the installer.

--- a/doc/cfgfile.rst
+++ b/doc/cfgfile.rst
@@ -225,7 +225,7 @@ the line with the key:
 
 .. describe:: local_wheels (optional)
 
-   One or more glob paths that matche one or more wheel files located on the
+   One or more glob paths that match one or more wheel files located on the
    local filesystem. All matching wheel files will be included in the installer.
    For instance ``wheels\*.whl`` will include all wheel files from the relative
    folder ``wheels``. 

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -79,7 +79,7 @@ class InstallerBuilder(object):
     :param extra_wheel_sources: Directory paths to find wheels in.
     :type extra_wheel_sources: list of Path objects
     :param local_wheels: Glob paths matching wheel files to include
-    :type local_wheels: list of glob paths
+    :type local_wheels: list of str
     :param list extra_files: List of 2-tuples (file, destination) of files to include
     :param list exclude: Paths of files to exclude that would otherwise be included
     :param str py_version: Full version of Python to bundle

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -78,8 +78,8 @@ class InstallerBuilder(object):
     :param list pypi_wheel_reqs: Package specifications to fetch from PyPI as wheels
     :param extra_wheel_sources: Directory paths to find wheels in.
     :type extra_wheel_sources: list of Path objects
-    :param local_wheels: Ant-formatted paths of wheels to include
-    :type local_wheels: list of Path objects
+    :param local_wheels: Glob paths matching wheel files to include
+    :type local_wheels: list of glob paths
     :param list extra_files: List of 2-tuples (file, destination) of files to include
     :param list exclude: Paths of files to exclude that would otherwise be included
     :param str py_version: Full version of Python to bundle

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -78,6 +78,8 @@ class InstallerBuilder(object):
     :param list pypi_wheel_reqs: Package specifications to fetch from PyPI as wheels
     :param extra_wheel_sources: Directory paths to find wheels in.
     :type extra_wheel_sources: list of Path objects
+    :param local_wheels: Ant-formatted paths of wheels to include
+    :type local_wheels: list of Path objects
     :param list extra_files: List of 2-tuples (file, destination) of files to include
     :param list exclude: Paths of files to exclude that would otherwise be included
     :param str py_version: Full version of Python to bundle
@@ -96,7 +98,7 @@ class InstallerBuilder(object):
                 py_format='bundled', inc_msvcrt=True, build_dir=DEFAULT_BUILD_DIR,
                 installer_name=None, nsi_template=None,
                 exclude=None, pypi_wheel_reqs=None, extra_wheel_sources=None,
-                commands=None, license_file=None):
+                local_wheels=None, commands=None, license_file=None):
         self.appname = appname
         self.version = version
         self.publisher = publisher
@@ -107,6 +109,7 @@ class InstallerBuilder(object):
         self.extra_files = extra_files or []
         self.pypi_wheel_reqs = pypi_wheel_reqs or []
         self.extra_wheel_sources = extra_wheel_sources or []
+        self.local_wheels = local_wheels or []
         self.commands = commands or {}
         self.license_file = license_file
 
@@ -347,8 +350,8 @@ if __name__ == '__main__':
         else:
             os.mkdir(build_pkg_dir)
 
-        # 2. Wheels from PyPI
-        fetch_pypi_wheels(self.pypi_wheel_reqs, build_pkg_dir,
+        # 2. Wheels specified in pypi_wheel_reqs or in paths of local_wheels
+        fetch_pypi_wheels(self.pypi_wheel_reqs, self.local_wheels, build_pkg_dir,
                           py_version=self.py_version, bitness=self.py_bitness,
                           extra_sources=self.extra_wheel_sources,
                           exclude=self.exclude)

--- a/nsist/configreader.py
+++ b/nsist/configreader.py
@@ -76,6 +76,7 @@ CONFIG_VALIDATORS = {
         ('extra_wheel_sources', False),
         ('files', False),
         ('exclude', False),
+        ('local_wheels', False)
     ]),
     'Python': SectionValidator([
         ('version', False),
@@ -235,4 +236,5 @@ def get_installer_builder_args(config):
     args['installer_name'] = config.get('Build', 'installer_name', fallback=None)
     args['nsi_template'] = config.get('Build', 'nsi_template', fallback=None)
     args['exclude'] = config.get('Include', 'exclude', fallback='').strip().splitlines()
+    args['local_wheels'] = config.get('Include', 'local_wheels', fallback='').strip().splitlines()
     return args

--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -270,7 +270,7 @@ def fetch_pypi_wheels(wheels_requirements, wheels_paths, target_dir, py_version,
         paths = glob.glob(glob_path)
         if not paths:
             raise ValueError('Error, glob path {0} does not match any wheel file'.format(glob_path))
-        for path in glob.glob(glob_path):
+        for path in paths:
             logger.info('Collecting wheel file: %s (from: %s)', os.path.basename(path), glob_path)
             validate_wheel(path, distributions, py_version, bitness)
             extract_wheel(path, target_dir, exclude=exclude)

--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -296,8 +296,8 @@ def validate_wheel(whl_path, wheel_info_array, py_version):
         raise ValueError('Error, wheel {0} does not support Python {1}'.format(wheel_info['wheel_name'], py_version))
 
     # Check that the wheel is compatible with Windows platforms
-    if wheel_info['platform_tag'] not in ['any', 'win32']:
-        raise ValueError('Error, wheel {0} does not support Windows platform'.format(wheel_info['platform_tag']))
+    if wheel_info['platform_tag'] not in ['any', 'win32', 'win_x86_64']:
+        raise ValueError('Error, wheel {0} does not support Windows platform'.format(wheel_info['wheel_name']))
 
     wheel_info_array.append(wheel_info)
 

--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -11,6 +11,7 @@ import re
 import shutil
 from tempfile import mkdtemp
 import zipfile
+import glob
 
 import yarg
 from requests_download import download, HashTracker
@@ -251,12 +252,16 @@ def extract_wheel(whl_file, target_dir, exclude=None):
     shutil.rmtree(str(td))
 
 
-def fetch_pypi_wheels(requirements, target_dir, py_version, bitness,
-                      extra_sources=None, exclude=None):
-    for req in requirements:
+def fetch_pypi_wheels(wheels_requirements, wheels_paths, target_dir, py_version,
+                      bitness, extra_sources=None, exclude=None):
+    for req in wheels_requirements:
         wl = WheelLocator(req, py_version, bitness, extra_sources)
         whl_file = wl.fetch()
         extract_wheel(whl_file, target_dir, exclude=exclude)
+
+    for glob_path in wheels_paths:
+        for path in glob.glob(glob_path):
+            extract_wheel(path, target_dir, exclude=exclude)
 
 
 def is_excluded(path, exclude):

--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -267,6 +267,9 @@ def fetch_pypi_wheels(wheels_requirements, wheels_paths, target_dir, py_version,
         extract_wheel(whl_file, target_dir, exclude=exclude)
     # Then from the local_wheels paths parameter
     for glob_path in wheels_paths:
+        paths = glob.glob(glob_path)
+        if not paths:
+            raise ValueError('Error, glob path {0} does not match any wheel file'.format(glob_path))
         for path in glob.glob(glob_path):
             logger.info('Include wheel: %s (local_wheels path: %s)', os.path.basename(path), glob_path)
             validate_wheel(path, wheel_info_array, py_version)

--- a/nsist/pypi.py
+++ b/nsist/pypi.py
@@ -2,16 +2,16 @@
 import fnmatch
 import hashlib
 import logging
-from pathlib import Path
-import re
-import shutil
-from tempfile import mkdtemp
-import zipfile
 import glob
 import os
-
+import re
+import shutil
 import yarg
+import zipfile
+
+from pathlib import Path
 from requests_download import download, HashTracker
+from tempfile import mkdtemp
 
 from .util import get_cache_dir, normalize_path
 
@@ -84,8 +84,8 @@ class WheelLocator(object):
         Returns a Path or None.
         """
         whl_filename_prefix = '{name}-{version}-'.format(
-            name=re.sub("[^\w\d.]+", "_", self.name),
-            version=re.sub("[^\w\d.]+", "_", self.version),
+            name=re.sub(r'[^\w\d.]+', '_', self.name),
+            version=re.sub(r'[^\w\d.]+', '_', self.version),
         )
         for source in self.extra_sources:
             candidates = [CachedRelease(p.name)

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -55,3 +55,10 @@ class TestLocalWheels(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, '{0} does not support Python {1}'
                 .format('incompatiblewheel-1.0.0-py26-none-any.whl', platform.python_version())):
                     fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+
+    def test_useless_wheel_glob_path_raise(self):
+        with TemporaryDirectory() as td1:
+            with TemporaryDirectory() as td2:
+                with self.assertRaisesRegex(ValueError, 'does not match any wheel file'
+                .format(td1)):
+                    fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -11,24 +11,24 @@ from nsist.pypi import fetch_pypi_wheels
 class TestLocalWheels(unittest.TestCase):
     def test_matching_one_pattern(self):
         with TemporaryDirectory() as td1:
-            subprocess.call(['pip', 'wheel', 'astsearch==0.1.2', '-w', td1])
+            subprocess.call(['pip', 'wheel', 'astsearch==0.1.3', '-w', td1])
 
             with TemporaryDirectory() as td2:
                 fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
                 assert_isfile(os.path.join(td2, 'astsearch.py'))
-                assert_isfile(os.path.join(td2, 'astsearch-0.1.2.dist-info', 'METADATA'))
+                assert_isfile(os.path.join(td2, 'astsearch-0.1.3.dist-info', 'METADATA'))
 
                 assert_isfile(os.path.join(td2, 'astcheck.py'))
                 self.assertTrue(glob.glob(os.path.join(td2, '*.dist-info')))
 
     def test_duplicate_wheel_files_raise(self):
         with TemporaryDirectory() as td1:
-            subprocess.call(['pip', 'wheel', 'astsearch==0.1.2', '-w', td1])
+            subprocess.call(['pip', 'wheel', 'astsearch==0.1.3', '-w', td1])
 
             with TemporaryDirectory() as td2:
                 with self.assertRaisesRegex(ValueError, 'wheel distribution astsearch already included'):
-                    fetch_pypi_wheels(['astsearch==0.1.2'], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+                    fetch_pypi_wheels(['astsearch==0.1.3'], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
     def test_invalid_wheel_file_raise(self):
         with TemporaryDirectory() as td1:

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -59,6 +59,10 @@ class TestLocalWheels(unittest.TestCase):
     def test_useless_wheel_glob_path_raise(self):
         with TemporaryDirectory() as td1:
             with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, 'does not match any wheel file'
-                .format(td1)):
+                with self.assertRaisesRegex(ValueError, 'does not match any wheel file'):
                     fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+
+
+# To exclude these, run:  nosetests -a '!network'
+TestLocalWheels.test_matching_one_pattern.network = 1
+TestLocalWheels.test_duplicate_wheel_files_raise.network = 1

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -5,30 +5,30 @@ import subprocess
 import glob
 
 from testpath.tempdir import TemporaryDirectory
-from testpath import assert_isfile
+from testpath import assert_isfile, assert_isdir
 from nsist.pypi import fetch_pypi_wheels
 
 class TestLocalWheels(unittest.TestCase):
     def test_matching_one_pattern(self):
         with TemporaryDirectory() as td1:
-            subprocess.call(['pip', 'wheel', 'astsearch==0.1.3', '-w', td1])
+            subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', td1])
 
             with TemporaryDirectory() as td2:
                 fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
-                assert_isfile(os.path.join(td2, 'astsearch.py'))
-                assert_isfile(os.path.join(td2, 'astsearch-0.1.3.dist-info', 'METADATA'))
+                assert_isdir(os.path.join(td2, 'requests'))
+                assert_isfile(os.path.join(td2, 'requests-2.19.1.dist-info', 'METADATA'))
 
-                assert_isfile(os.path.join(td2, 'astcheck.py'))
-                self.assertTrue(glob.glob(os.path.join(td2, '*.dist-info')))
+                assert_isdir(os.path.join(td2, 'urllib3'))
+                self.assertTrue(glob.glob(os.path.join(td2, 'urllib3*.dist-info')))
 
     def test_duplicate_wheel_files_raise(self):
         with TemporaryDirectory() as td1:
-            subprocess.call(['pip', 'wheel', 'astsearch==0.1.3', '-w', td1])
+            subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', td1])
 
             with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, 'wheel distribution astsearch already included'):
-                    fetch_pypi_wheels(['astsearch==0.1.3'], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+                with self.assertRaisesRegex(ValueError, 'wheel distribution requests already included'):
+                    fetch_pypi_wheels(['requests==2.19.1'], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
     def test_invalid_wheel_file_raise(self):
         with TemporaryDirectory() as td1:

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -43,8 +43,8 @@ class TestLocalWheels(unittest.TestCase):
             open(os.path.join(td1, 'incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl'), 'w+')
 
             with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, '{0} does not support Windows platform'
-                .format('incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl')):
+                with self.assertRaisesRegex(ValueError, '{0} is not compatible with Python {1} for Windows'
+                .format('incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl', platform.python_version())):
                     fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
     def test_incompatible_python_wheel_file_raise(self):
@@ -52,7 +52,7 @@ class TestLocalWheels(unittest.TestCase):
             open(os.path.join(td1, 'incompatiblewheel-1.0.0-py26-none-any.whl'), 'w+')
 
             with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, '{0} does not support Python {1}'
+                with self.assertRaisesRegex(ValueError, '{0} is not compatible with Python {1} for Windows'
                 .format('incompatiblewheel-1.0.0-py26-none-any.whl', platform.python_version())):
                     fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -1,0 +1,57 @@
+import unittest
+import os
+import platform
+import subprocess
+import glob
+
+from testpath.tempdir import TemporaryDirectory
+from testpath import assert_isfile
+from nsist.pypi import fetch_pypi_wheels
+
+class TestLocalWheels(unittest.TestCase):
+    def test_matching_one_pattern(self):
+        with TemporaryDirectory() as td1:
+            subprocess.call(['pip', 'wheel', 'astsearch==0.1.2', '-w', td1])
+
+            with TemporaryDirectory() as td2:
+                fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+
+                assert_isfile(os.path.join(td2, 'astsearch.py'))
+                assert_isfile(os.path.join(td2, 'astsearch-0.1.2.dist-info', 'METADATA'))
+
+                assert_isfile(os.path.join(td2, 'astcheck.py'))
+                self.assertTrue(glob.glob(os.path.join(td2, '*.dist-info')))
+
+    def test_duplicate_wheel_files_raise(self):
+        with TemporaryDirectory() as td1:
+            subprocess.call(['pip', 'wheel', 'astsearch==0.1.2', '-w', td1])
+
+            with TemporaryDirectory() as td2:
+                with self.assertRaisesRegex(ValueError, 'wheel distribution astsearch already included'):
+                    fetch_pypi_wheels(['astsearch==0.1.2'], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+
+    def test_invalid_wheel_file_raise(self):
+        with TemporaryDirectory() as td1:
+            open(os.path.join(td1, 'notawheel.txt'), 'w+')
+
+            with TemporaryDirectory() as td2:
+                with self.assertRaisesRegex(ValueError, 'Invalid wheel file name: notawheel.txt'):
+                    fetch_pypi_wheels([], [os.path.join(td1, '*')], td2, platform.python_version(), 64)
+
+    def test_incompatible_plateform_wheel_file_raise(self):
+        with TemporaryDirectory() as td1:
+            open(os.path.join(td1, 'incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl'), 'w+')
+
+            with TemporaryDirectory() as td2:
+                with self.assertRaisesRegex(ValueError, '{0} does not support Windows platform'
+                .format('incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl')):
+                    fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+
+    def test_incompatible_python_wheel_file_raise(self):
+        with TemporaryDirectory() as td1:
+            open(os.path.join(td1, 'incompatiblewheel-1.0.0-py26-none-any.whl'), 'w+')
+
+            with TemporaryDirectory() as td2:
+                with self.assertRaisesRegex(ValueError, '{0} does not support Python {1}'
+                .format('incompatiblewheel-1.0.0-py26-none-any.whl', platform.python_version())):
+                    fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)


### PR DESCRIPTION
Following #163 where we specified a mechanism to include local wheel files matching a path pattern.

Here is the PR to include all wheel files matching a list of glob paths specified in the `local_wheels` parameter, located under the `[Include]` section.

Matching wheel files will be processed into the installer the same way than wheels found from `wheels_pypi`.

Furthermore, any of the following situation will raise an error:
* two wheels to be included for the same distribution name
* a wheel to be included not compatible with the python version in the installer, or not compatible with Windows platforms.