### PR TITLE
Use tox+pytest to execute the tests, map to the CI systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ build/
 MANIFEST
 dist/
 doc/_build
-pynsist_pkgs/
+pynsist_pkgs
+.tox
 
 # This is a big file, so let it sit here after download
 examples/pygi_mpl_numpy/pygi.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - pip install tox-travis
 
 # Command to run tests
-script: tox
+script: tox -e python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+# Enable new Travis stack, should speed up builds
+sudo: false
 language: python
 python:
   - "3.6"
   - "3.5"
-# command to run tests
-script: nosetests
+
 # Ensure dependencies are installed
 install:
-  - pip install requests requests_download jinja2 yarg win_cli_launchers testpath
+  - pip install tox-travis
 
-# Enable new Travis stack, should speed up builds
-sudo: false
+# Command to run tests
+script: tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
 
 install:
   - cinst nsis
-  - "%PYTHON%\\python.exe -m pip install requests requests_download jinja2 yarg nose win_cli_launchers testpath"
+  - "%PYTHON%\\python.exe -m pip install tox"
 
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe -m nose"
+  - "%PYTHON%\\python.exe -m tox"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ install:
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe -m tox"
+  - "%PYTHON%\\python.exe -m tox -e python"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - cinst nsis
-  - "%PYTHON%\\python.exe -m pip install tox"
+  - "%PYTHON%\\python.exe -m pip install tox --no-warn-script-location"
 
 build: off
 

--- a/nsist/tests/test_commands.py
+++ b/nsist/tests/test_commands.py
@@ -1,36 +1,29 @@
 import io
-import unittest
 
 try:
     from pathlib import Path
 except ImportError:
     from pathlib2 import Path  # Backport
 
-from testpath.tempdir import TemporaryDirectory
-from testpath import assert_isfile
-
 from nsist import commands, _rewrite_shebangs
+from .utils import assert_is_file
 
-cmds = {'acommand': {
-                'entry_point': 'somemod:somefunc',
-                'extra_preamble': io.StringIO(u'import extra')
-           }}
+cmds = {'acommand': {'entry_point': 'somemod:somefunc',
+                     'extra_preamble': io.StringIO(u'import extra')}}
 
-class TestCommands(unittest.TestCase):
-    def test_prepare_bin_dir(self):
-        with TemporaryDirectory() as td:
-            td = Path(td)
-            commands.prepare_bin_directory(td, cmds)
-            assert_isfile(str(td / 'acommand.exe'))
-            script_file = td / 'acommand-script.py'
-            assert_isfile(str(script_file))
+def test_prepare_bin_dir(tmpdir):
+    tmpdir = Path(tmpdir)
+    commands.prepare_bin_directory(tmpdir, cmds)
+    assert_is_file(str(tmpdir / 'acommand.exe'))
+    script_file = tmpdir / 'acommand-script.py'
+    assert_is_file(str(script_file))
 
-            with script_file.open() as f:
-                script_contents = f.read()
-            assert script_contents.startswith("#!python")
-            self.assertIn('import extra', script_contents)
-            self.assertIn('somefunc()', script_contents)
+    with script_file.open() as f:
+        script_contents = f.read()
+    assert script_contents.startswith("#!python")
+    assert 'import extra' in script_contents
+    assert 'somefunc()' in script_contents
 
-            _rewrite_shebangs.main(['_rewrite_shebangs.py', str(td)])
-            with script_file.open() as f:
-                assert f.read().startswith('#!"')
+    _rewrite_shebangs.main(['_rewrite_shebangs.py', str(tmpdir)])
+    with script_file.open() as f:
+        assert f.read().startswith('#!"')

--- a/nsist/tests/test_commands.py
+++ b/nsist/tests/test_commands.py
@@ -12,7 +12,6 @@ cmds = {'acommand': {'entry_point': 'somemod:somefunc',
                      'extra_preamble': io.StringIO(u'import extra')}}
 
 def test_prepare_bin_dir(tmpdir):
-    tmpdir = Path(tmpdir)
     commands.prepare_bin_directory(tmpdir, cmds)
     assert_is_file(str(tmpdir / 'acommand.exe'))
     script_file = tmpdir / 'acommand-script.py'

--- a/nsist/tests/test_commands.py
+++ b/nsist/tests/test_commands.py
@@ -1,9 +1,11 @@
 import io
-from nose.tools import *
+import unittest
+
 try:
     from pathlib import Path
 except ImportError:
     from pathlib2 import Path  # Backport
+
 from testpath.tempdir import TemporaryDirectory
 from testpath import assert_isfile
 
@@ -14,20 +16,21 @@ cmds = {'acommand': {
                 'extra_preamble': io.StringIO(u'import extra')
            }}
 
-def test_prepare_bin_dir():
-    with TemporaryDirectory() as td:
-        td = Path(td)
-        commands.prepare_bin_directory(td, cmds)
-        assert_isfile(str(td / 'acommand.exe'))
-        script_file = td / 'acommand-script.py'
-        assert_isfile(str(script_file))
+class TestCommands(unittest.TestCase):
+    def test_prepare_bin_dir(self):
+        with TemporaryDirectory() as td:
+            td = Path(td)
+            commands.prepare_bin_directory(td, cmds)
+            assert_isfile(str(td / 'acommand.exe'))
+            script_file = td / 'acommand-script.py'
+            assert_isfile(str(script_file))
 
-        with script_file.open() as f:
-            script_contents = f.read()
-        assert script_contents.startswith("#!python")
-        assert_in('import extra', script_contents)
-        assert_in('somefunc()', script_contents)
+            with script_file.open() as f:
+                script_contents = f.read()
+            assert script_contents.startswith("#!python")
+            self.assertIn('import extra', script_contents)
+            self.assertIn('somefunc()', script_contents)
 
-        _rewrite_shebangs.main(['_rewrite_shebangs.py', str(td)])
-        with script_file.open() as f:
-            assert f.read().startswith('#!"')
+            _rewrite_shebangs.main(['_rewrite_shebangs.py', str(td)])
+            with script_file.open() as f:
+                assert f.read().startswith('#!"')

--- a/nsist/tests/test_configuration_validator.py
+++ b/nsist/tests/test_configuration_validator.py
@@ -1,76 +1,76 @@
 import configparser
 import os
-
-from nose.tools import *
+import unittest
 
 from .. import configreader
 
 
 DATA_FILES = os.path.join(os.path.dirname(__file__), 'data_files')
 
-def test_valid_config():
-    configfile = os.path.join(DATA_FILES, 'valid_config.cfg')
-    config = configreader.read_and_validate(configfile)
-    assert config.has_section('Application')
-    args = configreader.get_installer_builder_args(config)
-    assert args['py_version'] == '3.4.0'
+class TestConfigurationValidator(unittest.TestCase):
+    def test_valid_config(self):
+        configfile = os.path.join(DATA_FILES, 'valid_config.cfg')
+        config = configreader.read_and_validate(configfile)
+        assert config.has_section('Application')
+        args = configreader.get_installer_builder_args(config)
+        assert args['py_version'] == '3.4.0'
 
-def test_valid_config_with_shortcut():
-    configfile = os.path.join(DATA_FILES, 'valid_config_with_shortcut.cfg')
-    config = configreader.read_and_validate(configfile)
+    def test_valid_config_with_shortcut(self):
+        configfile = os.path.join(DATA_FILES, 'valid_config_with_shortcut.cfg')
+        configreader.read_and_validate(configfile)
 
-def test_valid_config_with_values_starting_on_new_line():
-    configfile = os.path.join(DATA_FILES, 'valid_config_value_newline.cfg')
-    config = configreader.read_and_validate(configfile)
-    sections = ('Application', 'Python', 'Include', 'Build')
-    assert len(config.sections()) == len(sections)
-    for section in sections:
-        assert section in config
+    def test_valid_config_with_values_starting_on_new_line(self):
+        configfile = os.path.join(DATA_FILES, 'valid_config_value_newline.cfg')
+        config = configreader.read_and_validate(configfile)
+        sections = ('Application', 'Python', 'Include', 'Build')
+        assert len(config.sections()) == len(sections)
+        for section in sections:
+            assert section in config
 
-    assert config.get('Include', 'packages') == '\nrequests\nbs4'
-    assert config.get('Include', 'pypi_wheels') == '\nhtml5lib'
-    assert config.get('Include', 'exclude') == '\nsomething'
-    assert config.get('Include', 'files') == '\nLICENSE\ndata_files/'
+        assert config.get('Include', 'packages') == '\nrequests\nbs4'
+        assert config.get('Include', 'pypi_wheels') == '\nhtml5lib'
+        assert config.get('Include', 'exclude') == '\nsomething'
+        assert config.get('Include', 'files') == '\nLICENSE\ndata_files/'
 
-    args = configreader.get_installer_builder_args(config)
-    assert args['appname'] == 'My App'
-    assert args['version'] == '1.0'
-    assert args['shortcuts']['My App']['entry_point'] == 'myapp:main'
-    assert args['commands'] == {}
-    assert args['publisher'] == 'Test'
-    # assert args['entry_point'] == '\nmyapp:main'
-    assert args['icon'] == 'myapp.ico'
+        args = configreader.get_installer_builder_args(config)
+        assert args['appname'] == 'My App'
+        assert args['version'] == '1.0'
+        assert args['shortcuts']['My App']['entry_point'] == 'myapp:main'
+        assert args['commands'] == {}
+        assert args['publisher'] == 'Test'
+        # assert args['entry_point'] == '\nmyapp:main'
+        assert args['icon'] == 'myapp.ico'
 
-    assert args['py_version'] == '3.6.0'
-    assert args['py_bitness'] == 64
-    assert args['inc_msvcrt'] == True
+        assert args['py_version'] == '3.6.0'
+        assert args['py_bitness'] == 64
+        assert args['inc_msvcrt'] == True
 
-    assert args['build_dir'] == 'build/'
-    assert args['nsi_template'] == 'template.nsi'
+        assert args['build_dir'] == 'build/'
+        assert args['nsi_template'] == 'template.nsi'
 
-    assert args['packages'] == ['requests', 'bs4']
-    assert args['pypi_wheel_reqs'] == ['html5lib']
-    assert args['exclude'] == ['something']
-    assert args['extra_files'] == [('', '$INSTDIR'),
-                                    ('LICENSE', '$INSTDIR'),
-                                    ('data_files/', '$INSTDIR')]
+        assert args['packages'] == ['requests', 'bs4']
+        assert args['pypi_wheel_reqs'] == ['html5lib']
+        assert args['exclude'] == ['something']
+        assert args['extra_files'] == [('', '$INSTDIR'),
+                                        ('LICENSE', '$INSTDIR'),
+                                        ('data_files/', '$INSTDIR')]
 
-@raises(configreader.InvalidConfig)
-def test_invalid_config_keys():
-    configfile = os.path.join(DATA_FILES, 'invalid_config_section.cfg')
-    configreader.read_and_validate(configfile)
+    def test_invalid_config_keys(self):
+        with self.assertRaises(configreader.InvalidConfig):
+            configfile = os.path.join(DATA_FILES, 'invalid_config_section.cfg')
+            configreader.read_and_validate(configfile)
 
-@raises(configreader.InvalidConfig)
-def test_invalid_config_key():
-    configfile = os.path.join(DATA_FILES, 'invalid_config_key.cfg')
-    configreader.read_and_validate(configfile)
+    def test_invalid_config_key(self):
+        with self.assertRaises(configreader.InvalidConfig):
+            configfile = os.path.join(DATA_FILES, 'invalid_config_key.cfg')
+            configreader.read_and_validate(configfile)
 
-@raises(configreader.InvalidConfig)
-def test_missing_config_key():
-    configfile = os.path.join(DATA_FILES, 'missing_config_key.cfg')
-    configreader.read_and_validate(configfile)
+    def test_missing_config_key(self):
+        with self.assertRaises(configreader.InvalidConfig):
+            configfile = os.path.join(DATA_FILES, 'missing_config_key.cfg')
+            configreader.read_and_validate(configfile)
 
-@raises(configparser.Error)
-def test_invalid_config_file():
-    configfile = os.path.join(DATA_FILES, 'not_a_config.cfg')
-    configreader.read_and_validate(configfile)
+    def test_invalid_config_file(self):
+        with self.assertRaises(configparser.Error):
+            configfile = os.path.join(DATA_FILES, 'not_a_config.cfg')
+            configreader.read_and_validate(configfile)

--- a/nsist/tests/test_configuration_validator.py
+++ b/nsist/tests/test_configuration_validator.py
@@ -1,76 +1,76 @@
 import configparser
 import os
-import unittest
+
+import pytest
 
 from .. import configreader
 
 
 DATA_FILES = os.path.join(os.path.dirname(__file__), 'data_files')
 
-class TestConfigurationValidator(unittest.TestCase):
-    def test_valid_config(self):
-        configfile = os.path.join(DATA_FILES, 'valid_config.cfg')
-        config = configreader.read_and_validate(configfile)
-        assert config.has_section('Application')
-        args = configreader.get_installer_builder_args(config)
-        assert args['py_version'] == '3.4.0'
+def test_valid_config():
+    configfile = os.path.join(DATA_FILES, 'valid_config.cfg')
+    config = configreader.read_and_validate(configfile)
+    assert config.has_section('Application')
+    args = configreader.get_installer_builder_args(config)
+    assert args['py_version'] == '3.4.0'
 
-    def test_valid_config_with_shortcut(self):
-        configfile = os.path.join(DATA_FILES, 'valid_config_with_shortcut.cfg')
+def test_valid_config_with_shortcut():
+    configfile = os.path.join(DATA_FILES, 'valid_config_with_shortcut.cfg')
+    configreader.read_and_validate(configfile)
+
+def test_valid_config_with_values_starting_on_new_line():
+    configfile = os.path.join(DATA_FILES, 'valid_config_value_newline.cfg')
+    config = configreader.read_and_validate(configfile)
+    sections = ('Application', 'Python', 'Include', 'Build')
+    assert len(config.sections()) == len(sections)
+    for section in sections:
+        assert section in config
+
+    assert config.get('Include', 'packages') == '\nrequests\nbs4'
+    assert config.get('Include', 'pypi_wheels') == '\nhtml5lib'
+    assert config.get('Include', 'exclude') == '\nsomething'
+    assert config.get('Include', 'files') == '\nLICENSE\ndata_files/'
+
+    args = configreader.get_installer_builder_args(config)
+    assert args['appname'] == 'My App'
+    assert args['version'] == '1.0'
+    assert args['shortcuts']['My App']['entry_point'] == 'myapp:main'
+    assert args['commands'] == {}
+    assert args['publisher'] == 'Test'
+    # assert args['entry_point'] == '\nmyapp:main'
+    assert args['icon'] == 'myapp.ico'
+
+    assert args['py_version'] == '3.6.0'
+    assert args['py_bitness'] == 64
+    assert args['inc_msvcrt'] is True
+
+    assert args['build_dir'] == 'build/'
+    assert args['nsi_template'] == 'template.nsi'
+
+    assert args['packages'] == ['requests', 'bs4']
+    assert args['pypi_wheel_reqs'] == ['html5lib']
+    assert args['exclude'] == ['something']
+    assert args['extra_files'] == [('', '$INSTDIR'),
+                                   ('LICENSE', '$INSTDIR'),
+                                   ('data_files/', '$INSTDIR')]
+
+def test_invalid_config_keys():
+    with pytest.raises(configreader.InvalidConfig):
+        configfile = os.path.join(DATA_FILES, 'invalid_config_section.cfg')
         configreader.read_and_validate(configfile)
 
-    def test_valid_config_with_values_starting_on_new_line(self):
-        configfile = os.path.join(DATA_FILES, 'valid_config_value_newline.cfg')
-        config = configreader.read_and_validate(configfile)
-        sections = ('Application', 'Python', 'Include', 'Build')
-        assert len(config.sections()) == len(sections)
-        for section in sections:
-            assert section in config
+def test_invalid_config_key():
+    with pytest.raises(configreader.InvalidConfig):
+        configfile = os.path.join(DATA_FILES, 'invalid_config_key.cfg')
+        configreader.read_and_validate(configfile)
 
-        assert config.get('Include', 'packages') == '\nrequests\nbs4'
-        assert config.get('Include', 'pypi_wheels') == '\nhtml5lib'
-        assert config.get('Include', 'exclude') == '\nsomething'
-        assert config.get('Include', 'files') == '\nLICENSE\ndata_files/'
+def test_missing_config_key():
+    with pytest.raises(configreader.InvalidConfig):
+        configfile = os.path.join(DATA_FILES, 'missing_config_key.cfg')
+        configreader.read_and_validate(configfile)
 
-        args = configreader.get_installer_builder_args(config)
-        assert args['appname'] == 'My App'
-        assert args['version'] == '1.0'
-        assert args['shortcuts']['My App']['entry_point'] == 'myapp:main'
-        assert args['commands'] == {}
-        assert args['publisher'] == 'Test'
-        # assert args['entry_point'] == '\nmyapp:main'
-        assert args['icon'] == 'myapp.ico'
-
-        assert args['py_version'] == '3.6.0'
-        assert args['py_bitness'] == 64
-        assert args['inc_msvcrt'] == True
-
-        assert args['build_dir'] == 'build/'
-        assert args['nsi_template'] == 'template.nsi'
-
-        assert args['packages'] == ['requests', 'bs4']
-        assert args['pypi_wheel_reqs'] == ['html5lib']
-        assert args['exclude'] == ['something']
-        assert args['extra_files'] == [('', '$INSTDIR'),
-                                        ('LICENSE', '$INSTDIR'),
-                                        ('data_files/', '$INSTDIR')]
-
-    def test_invalid_config_keys(self):
-        with self.assertRaises(configreader.InvalidConfig):
-            configfile = os.path.join(DATA_FILES, 'invalid_config_section.cfg')
-            configreader.read_and_validate(configfile)
-
-    def test_invalid_config_key(self):
-        with self.assertRaises(configreader.InvalidConfig):
-            configfile = os.path.join(DATA_FILES, 'invalid_config_key.cfg')
-            configreader.read_and_validate(configfile)
-
-    def test_missing_config_key(self):
-        with self.assertRaises(configreader.InvalidConfig):
-            configfile = os.path.join(DATA_FILES, 'missing_config_key.cfg')
-            configreader.read_and_validate(configfile)
-
-    def test_invalid_config_file(self):
-        with self.assertRaises(configparser.Error):
-            configfile = os.path.join(DATA_FILES, 'not_a_config.cfg')
-            configreader.read_and_validate(configfile)
+def test_invalid_config_file():
+    with pytest.raises(configparser.Error):
+        configfile = os.path.join(DATA_FILES, 'not_a_config.cfg')
+        configreader.read_and_validate(configfile)

--- a/nsist/tests/test_copymodules.py
+++ b/nsist/tests/test_copymodules.py
@@ -46,10 +46,10 @@ class TestCopyModules(unittest.TestCase):
         
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_copy_wrong_pyversion(self):
-        with self.assertRaisesRegexp(ExtensionModuleMismatch, "on Python 4"):
+        with self.assertRaisesRegex(ExtensionModuleMismatch, "on Python 4"):
             copy_modules(['win_extpkg'], self.target, '4.0.0', sample_path)
         
-        with self.assertRaisesRegexp(ExtensionModuleMismatch, "on Python 4"):
+        with self.assertRaisesRegex(ExtensionModuleMismatch, "on Python 4"):
             copy_modules(['win_extmod'], self.target, '4.0.0', sample_path)
     
     def test_copy_from_zipfile(self):

--- a/nsist/tests/test_copymodules.py
+++ b/nsist/tests/test_copymodules.py
@@ -1,13 +1,12 @@
 import os
-import shutil
 import sys
-import tempfile
-import unittest
+
+import pytest
+
+from nsist.copymodules import copy_modules, ExtensionModuleMismatch
+from .utils import assert_is_file, assert_is_dir, test_dir, skip_on_windows, only_on_windows
 
 pjoin = os.path.join
-
-from .utils import assert_is_file, assert_is_dir, test_dir
-
 running_python = '.'.join(str(x) for x in sys.version_info[:3])
 
 sample_path = [pjoin(test_dir, 'sample_pkgs'),
@@ -15,51 +14,42 @@ sample_path = [pjoin(test_dir, 'sample_pkgs'),
                pjoin(test_dir, 'sample_zip.egg/rootdir'),
               ]
 
-from nsist.copymodules import copy_modules, ExtensionModuleMismatch
 
+def test_copy_plain(tmpdir):
+    copy_modules(['plainmod', 'plainpkg'], tmpdir, '3.3.5', sample_path)
+    assert_is_file(pjoin(tmpdir, 'plainmod.py'))
+    assert_is_dir(pjoin(tmpdir, 'plainpkg'))
 
-class TestCopyModules(unittest.TestCase):
-    def setUp(self):
-        self.target = tempfile.mkdtemp()
-    
-    def tearDown(self):
-        shutil.rmtree(self.target)
-    
-    def test_copy_plain(self):
-        copy_modules(['plainmod', 'plainpkg'], self.target, '3.3.5', sample_path)
-        assert_is_file(pjoin(self.target, 'plainmod.py'))
-        assert_is_dir(pjoin(self.target, 'plainpkg'))
-    
-    @unittest.skipIf(sys.platform.startswith("win"), "test for non-Windows platforms")
-    def test_copy_wrong_platform(self):
-        with self.assertRaisesRegexp(ExtensionModuleMismatch, "will not be usable on Windows"):
-            copy_modules(['unix_extmod'], self.target, '3.3.5', sample_path)
-        
-        with self.assertRaisesRegexp(ExtensionModuleMismatch, "will not be usable on Windows"):
-            copy_modules(['unix_extpkg'], self.target, '3.3.5', sample_path)
-    
-    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
-    def test_copy_windows(self):
-        copy_modules(['win_extmod', 'win_extpkg'], self.target, running_python, sample_path)
-        assert_is_file(pjoin(self.target, 'win_extmod.pyd'))
-        assert_is_dir(pjoin(self.target, 'win_extpkg'))
-        
-    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
-    def test_copy_wrong_pyversion(self):
-        with self.assertRaisesRegex(ExtensionModuleMismatch, "on Python 4"):
-            copy_modules(['win_extpkg'], self.target, '4.0.0', sample_path)
-        
-        with self.assertRaisesRegex(ExtensionModuleMismatch, "on Python 4"):
-            copy_modules(['win_extmod'], self.target, '4.0.0', sample_path)
-    
-    def test_copy_from_zipfile(self):
-        copy_modules(['zippedmod2','zippedpkg2'],
-                     self.target, running_python, sample_path)
-#        assert_is_file(pjoin(self.target, 'zippedmod.py'))
-#        assert_is_dir(pjoin(self.target, 'zippedpkg'))
-        assert_is_file(pjoin(self.target, 'zippedmod2.py'))
-        assert_is_dir(pjoin(self.target, 'zippedpkg2'))
-    
-    def test_module_not_found(self):
-        with self.assertRaises(ImportError):
-            copy_modules(['nonexistant'], self.target, '3.3.5', sample_path)
+@skip_on_windows
+def test_copy_wrong_platform(tmpdir):
+    with pytest.raises(ExtensionModuleMismatch, match="will not be usable on Windows"):
+        copy_modules(['unix_extmod'], tmpdir, '3.3.5', sample_path)
+
+    with pytest.raises(ExtensionModuleMismatch, match="will not be usable on Windows"):
+        copy_modules(['unix_extpkg'], tmpdir, '3.3.5', sample_path)
+
+@only_on_windows
+def test_copy_windows(tmpdir):
+    copy_modules(['win_extmod', 'win_extpkg'], tmpdir, running_python, sample_path)
+    assert_is_file(pjoin(tmpdir, 'win_extmod.pyd'))
+    assert_is_dir(pjoin(tmpdir, 'win_extpkg'))
+
+@only_on_windows
+def test_copy_wrong_pyversion(tmpdir):
+    with pytest.raises(ExtensionModuleMismatch, match="on Python 4"):
+        copy_modules(['win_extpkg'], tmpdir, '4.0.0', sample_path)
+
+    with pytest.raises(ExtensionModuleMismatch, match="on Python 4"):
+        copy_modules(['win_extmod'], tmpdir, '4.0.0', sample_path)
+
+def test_copy_from_zipfile(tmpdir):
+    copy_modules(['zippedmod2', 'zippedpkg2'],
+                 tmpdir, running_python, sample_path)
+#        assert_is_file(pjoin(tmpdir, 'zippedmod.py'))
+#        assert_is_dir(pjoin(tmpdir, 'zippedpkg'))
+    assert_is_file(pjoin(tmpdir, 'zippedmod2.py'))
+    assert_is_dir(pjoin(tmpdir, 'zippedpkg2'))
+
+def test_module_not_found(tmpdir):
+    with pytest.raises(ImportError):
+        copy_modules(['nonexistant'], tmpdir, '3.3.5', sample_path)

--- a/nsist/tests/test_copymodules.py
+++ b/nsist/tests/test_copymodules.py
@@ -16,12 +16,14 @@ sample_path = [pjoin(test_dir, 'sample_pkgs'),
 
 
 def test_copy_plain(tmpdir):
+    tmpdir = str(tmpdir)
     copy_modules(['plainmod', 'plainpkg'], tmpdir, '3.3.5', sample_path)
     assert_is_file(pjoin(tmpdir, 'plainmod.py'))
     assert_is_dir(pjoin(tmpdir, 'plainpkg'))
 
 @skip_on_windows
 def test_copy_wrong_platform(tmpdir):
+    tmpdir = str(tmpdir)
     with pytest.raises(ExtensionModuleMismatch, match="will not be usable on Windows"):
         copy_modules(['unix_extmod'], tmpdir, '3.3.5', sample_path)
 
@@ -30,12 +32,14 @@ def test_copy_wrong_platform(tmpdir):
 
 @only_on_windows
 def test_copy_windows(tmpdir):
+    tmpdir = str(tmpdir)
     copy_modules(['win_extmod', 'win_extpkg'], tmpdir, running_python, sample_path)
     assert_is_file(pjoin(tmpdir, 'win_extmod.pyd'))
     assert_is_dir(pjoin(tmpdir, 'win_extpkg'))
 
 @only_on_windows
 def test_copy_wrong_pyversion(tmpdir):
+    tmpdir = str(tmpdir)
     with pytest.raises(ExtensionModuleMismatch, match="on Python 4"):
         copy_modules(['win_extpkg'], tmpdir, '4.0.0', sample_path)
 
@@ -43,6 +47,7 @@ def test_copy_wrong_pyversion(tmpdir):
         copy_modules(['win_extmod'], tmpdir, '4.0.0', sample_path)
 
 def test_copy_from_zipfile(tmpdir):
+    tmpdir = str(tmpdir)
     copy_modules(['zippedmod2', 'zippedpkg2'],
                  tmpdir, running_python, sample_path)
 #        assert_is_file(pjoin(tmpdir, 'zippedmod.py'))
@@ -51,5 +56,6 @@ def test_copy_from_zipfile(tmpdir):
     assert_is_dir(pjoin(tmpdir, 'zippedpkg2'))
 
 def test_module_not_found(tmpdir):
+    tmpdir = str(tmpdir)
     with pytest.raises(ImportError):
         copy_modules(['nonexistant'], tmpdir, '3.3.5', sample_path)

--- a/nsist/tests/test_installerbuilder.py
+++ b/nsist/tests/test_installerbuilder.py
@@ -9,6 +9,7 @@ from .utils import assert_is_file, test_dir
 sample_preamble = pjoin(test_dir, u'sample_preamble.py')
 
 def test_prepare_shortcuts(tmpdir):
+    tmpdir = str(tmpdir)
     shortcuts = {'sc1': {'entry_point': 'norwegian.blue:parrot',
                          'icon': DEFAULT_ICON,
                          'console': False,

--- a/nsist/tests/test_installerbuilder.py
+++ b/nsist/tests/test_installerbuilder.py
@@ -1,41 +1,31 @@
 import io
-from os.path import join as pjoin
-import shutil
-import tempfile
-import unittest
 
-from .utils import assert_is_file, test_dir
+from os.path import join as pjoin
+
 from nsist import InstallerBuilder, DEFAULT_ICON
+from .utils import assert_is_file, test_dir
+
 
 sample_preamble = pjoin(test_dir, u'sample_preamble.py')
 
-class TestInstallerBuilder(unittest.TestCase):
-    def setUp(self):
-        self.target = tempfile.mkdtemp()
-    
-    def tearDown(self):
-        shutil.rmtree(self.target)
-    
-    def test_prepare_shortcuts(self):
-        shortcuts = {'sc1': {'entry_point': 'norwegian.blue:parrot',
-                             'icon': DEFAULT_ICON,
-                             'console': False,
-                             'extra_preamble': sample_preamble,
-                             }
-                    }
-        ib = InstallerBuilder("Test App", "1.0", shortcuts, build_dir=self.target)
-        ib.prepare_shortcuts()
-        
-        scfile = pjoin(self.target, 'sc1.launch.pyw')
-        assert_is_file(scfile)
-        
-        with io.open(scfile, 'r', encoding='utf-8') as f:
-            contents = f.read()
-        
-        last2lines = [l.strip() for l in contents.rstrip().splitlines()[-2:]]
-        assert last2lines == ['from norwegian.blue import parrot', 'parrot()']
-        
-        with io.open(sample_preamble, 'r', encoding='utf-8') as f:
-            preamble_contents = f.read().strip()
-        
-        assert preamble_contents in contents
+def test_prepare_shortcuts(tmpdir):
+    shortcuts = {'sc1': {'entry_point': 'norwegian.blue:parrot',
+                         'icon': DEFAULT_ICON,
+                         'console': False,
+                         'extra_preamble': sample_preamble}}
+    ib = InstallerBuilder("Test App", "1.0", shortcuts, build_dir=tmpdir)
+    ib.prepare_shortcuts()
+
+    scfile = pjoin(tmpdir, 'sc1.launch.pyw')
+    assert_is_file(scfile)
+
+    with io.open(scfile, 'r', encoding='utf-8') as f:
+        contents = f.read()
+
+    last2lines = [l.strip() for l in contents.rstrip().splitlines()[-2:]]
+    assert last2lines == ['from norwegian.blue import parrot', 'parrot()']
+
+    with io.open(sample_preamble, 'r', encoding='utf-8') as f:
+        preamble_contents = f.read().strip()
+
+    assert preamble_contents in contents

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import platform
+import pytest
 import subprocess
 import glob
 
@@ -8,7 +9,10 @@ from testpath.tempdir import TemporaryDirectory
 from testpath import assert_isfile, assert_isdir
 from nsist.pypi import fetch_pypi_wheels
 
+# To exclude tests requiring network on an unplugged machine, use: pytest -m "not network"
+
 class TestLocalWheels(unittest.TestCase):
+    @pytest.mark.network
     def test_matching_one_pattern(self):
         with TemporaryDirectory() as td1:
             subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', td1])
@@ -22,6 +26,7 @@ class TestLocalWheels(unittest.TestCase):
                 assert_isdir(os.path.join(td2, 'urllib3'))
                 self.assertTrue(glob.glob(os.path.join(td2, 'urllib3*.dist-info')))
 
+    @pytest.mark.network
     def test_duplicate_wheel_files_raise(self):
         with TemporaryDirectory() as td1:
             subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', td1])
@@ -62,7 +67,3 @@ class TestLocalWheels(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, 'does not match any wheel file'):
                     fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
-
-# To exclude these, run:  nosetests -a '!network'
-TestLocalWheels.test_matching_one_pattern.network = 1
-TestLocalWheels.test_duplicate_wheel_files_raise.network = 1

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -1,69 +1,75 @@
-import unittest
+import glob
 import os
 import platform
-import pytest
 import subprocess
-import glob
 
-from testpath.tempdir import TemporaryDirectory
-from testpath import assert_isfile, assert_isdir
+import pytest
+
 from nsist.pypi import fetch_pypi_wheels
+from .utils import assert_is_dir, assert_is_file
 
 # To exclude tests requiring network on an unplugged machine, use: pytest -m "not network"
 
-class TestLocalWheels(unittest.TestCase):
-    @pytest.mark.network
-    def test_matching_one_pattern(self):
-        with TemporaryDirectory() as td1:
-            subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', td1])
+@pytest.mark.network
+def test_matching_one_pattern(tmpdir):
+    td1 = tmpdir.mkdir('wheels')
+    td2 = tmpdir.mkdir('pkgs')
 
-            with TemporaryDirectory() as td2:
-                fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+    subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', str(td1)])
 
-                assert_isdir(os.path.join(td2, 'requests'))
-                assert_isfile(os.path.join(td2, 'requests-2.19.1.dist-info', 'METADATA'))
+    fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
-                assert_isdir(os.path.join(td2, 'urllib3'))
-                self.assertTrue(glob.glob(os.path.join(td2, 'urllib3*.dist-info')))
+    assert_is_dir(os.path.join(td2, 'requests'))
+    assert_is_file(os.path.join(td2, 'requests-2.19.1.dist-info', 'METADATA'))
 
-    @pytest.mark.network
-    def test_duplicate_wheel_files_raise(self):
-        with TemporaryDirectory() as td1:
-            subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', td1])
+    assert_is_dir(os.path.join(td2, 'urllib3'))
+    assert glob.glob(os.path.join(td2, 'urllib3*.dist-info'))
 
-            with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, 'wheel distribution requests already included'):
-                    fetch_pypi_wheels(['requests==2.19.1'], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+@pytest.mark.network
+def test_duplicate_wheel_files_raise(tmpdir):
+    td1 = tmpdir.mkdir('wheels')
+    td2 = tmpdir.mkdir('pkgs')
 
-    def test_invalid_wheel_file_raise(self):
-        with TemporaryDirectory() as td1:
-            open(os.path.join(td1, 'notawheel.txt'), 'w+')
+    subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', str(td1)])
 
-            with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, 'Invalid wheel file name: notawheel.txt'):
-                    fetch_pypi_wheels([], [os.path.join(td1, '*')], td2, platform.python_version(), 64)
+    with pytest.raises(ValueError, match='wheel distribution requests already included'):
+        fetch_pypi_wheels(['requests==2.19.1'],
+                          [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
-    def test_incompatible_plateform_wheel_file_raise(self):
-        with TemporaryDirectory() as td1:
-            open(os.path.join(td1, 'incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl'), 'w+')
+def test_invalid_wheel_file_raise(tmpdir):
+    td1 = tmpdir.mkdir('wheels')
+    td2 = tmpdir.mkdir('pkgs')
 
-            with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, '{0} is not compatible with Python {1} for Windows'
-                .format('incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl', platform.python_version())):
-                    fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+    open(os.path.join(td1, 'notawheel.txt'), 'w+')
 
-    def test_incompatible_python_wheel_file_raise(self):
-        with TemporaryDirectory() as td1:
-            open(os.path.join(td1, 'incompatiblewheel-1.0.0-py26-none-any.whl'), 'w+')
+    with pytest.raises(ValueError, match='Invalid wheel file name: notawheel.txt'):
+        fetch_pypi_wheels([], [os.path.join(td1, '*')], td2, platform.python_version(), 64)
 
-            with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, '{0} is not compatible with Python {1} for Windows'
-                .format('incompatiblewheel-1.0.0-py26-none-any.whl', platform.python_version())):
-                    fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+def test_incompatible_plateform_wheel_file_raise(tmpdir):
+    td1 = tmpdir.mkdir('wheels')
+    td2 = tmpdir.mkdir('pkgs')
 
-    def test_useless_wheel_glob_path_raise(self):
-        with TemporaryDirectory() as td1:
-            with TemporaryDirectory() as td2:
-                with self.assertRaisesRegex(ValueError, 'does not match any wheel file'):
-                    fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+    open(os.path.join(td1, 'incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl'), 'w+')
 
+    with pytest.raises(ValueError, match='{0} is not compatible with Python {1} for Windows'
+                       .format('incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl',
+                               platform.python_version())):
+        fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+
+def test_incompatible_python_wheel_file_raise(tmpdir):
+    td1 = tmpdir.mkdir('wheels')
+    td2 = tmpdir.mkdir('pkgs')
+
+    open(os.path.join(td1, 'incompatiblewheel-1.0.0-py26-none-any.whl'), 'w+')
+
+    with pytest.raises(ValueError, match='{0} is not compatible with Python {1} for Windows'
+                       .format('incompatiblewheel-1.0.0-py26-none-any.whl',
+                               platform.python_version())):
+        fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
+
+def test_useless_wheel_glob_path_raise(tmpdir):
+    td1 = tmpdir.mkdir('wheels')
+    td2 = tmpdir.mkdir('pkgs')
+
+    with pytest.raises(ValueError, match='does not match any wheel file'):
+        fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)

--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -12,8 +12,8 @@ from .utils import assert_is_dir, assert_is_file
 
 @pytest.mark.network
 def test_matching_one_pattern(tmpdir):
-    td1 = tmpdir.mkdir('wheels')
-    td2 = tmpdir.mkdir('pkgs')
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
 
     subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', str(td1)])
 
@@ -27,8 +27,8 @@ def test_matching_one_pattern(tmpdir):
 
 @pytest.mark.network
 def test_duplicate_wheel_files_raise(tmpdir):
-    td1 = tmpdir.mkdir('wheels')
-    td2 = tmpdir.mkdir('pkgs')
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
 
     subprocess.call(['pip', 'wheel', 'requests==2.19.1', '-w', str(td1)])
 
@@ -37,8 +37,8 @@ def test_duplicate_wheel_files_raise(tmpdir):
                           [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
 def test_invalid_wheel_file_raise(tmpdir):
-    td1 = tmpdir.mkdir('wheels')
-    td2 = tmpdir.mkdir('pkgs')
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
 
     open(os.path.join(td1, 'notawheel.txt'), 'w+')
 
@@ -46,8 +46,8 @@ def test_invalid_wheel_file_raise(tmpdir):
         fetch_pypi_wheels([], [os.path.join(td1, '*')], td2, platform.python_version(), 64)
 
 def test_incompatible_plateform_wheel_file_raise(tmpdir):
-    td1 = tmpdir.mkdir('wheels')
-    td2 = tmpdir.mkdir('pkgs')
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
 
     open(os.path.join(td1, 'incompatiblewheel-1.0.0-py2.py3-none-linux_x86_64.whl'), 'w+')
 
@@ -57,8 +57,8 @@ def test_incompatible_plateform_wheel_file_raise(tmpdir):
         fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
 def test_incompatible_python_wheel_file_raise(tmpdir):
-    td1 = tmpdir.mkdir('wheels')
-    td2 = tmpdir.mkdir('pkgs')
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
 
     open(os.path.join(td1, 'incompatiblewheel-1.0.0-py26-none-any.whl'), 'w+')
 
@@ -68,8 +68,8 @@ def test_incompatible_python_wheel_file_raise(tmpdir):
         fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)
 
 def test_useless_wheel_glob_path_raise(tmpdir):
-    td1 = tmpdir.mkdir('wheels')
-    td2 = tmpdir.mkdir('pkgs')
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
 
     with pytest.raises(ValueError, match='does not match any wheel file'):
         fetch_pypi_wheels([], [os.path.join(td1, '*.whl')], td2, platform.python_version(), 64)

--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -1,149 +1,147 @@
-import pytest
-import unittest
-
 from os.path import join as pjoin
 from pathlib import Path
-from testpath import assert_isfile, assert_isdir
-from testpath.tempdir import TemporaryDirectory
+import pytest
 
 from nsist.pypi import (
     WheelLocator, extract_wheel, CachedRelease, merge_dir_to, NoWheelError,
 )
+from .utils import assert_is_file
 
 # To exclude tests requiring network on an unplugged machine, use: pytest -m "not network"
 
-class TestPyPi(unittest.TestCase):
-    @pytest.mark.network
-    def test_download(self):
-        wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
-        wheel = wd.fetch()
-        assert_isfile(str(wheel))
+@pytest.mark.network
+def test_download(tmpdir):
+    wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
+    wheel = wd.fetch()
+    assert_is_file(str(wheel))
 
-        with TemporaryDirectory() as td:
-            extract_wheel(wheel, target_dir=td)
-            assert_isfile(pjoin(td, 'astsearch.py'))
-            assert_isfile(pjoin(td, 'astsearch-0.1.2.dist-info', 'METADATA'))
+    extract_wheel(wheel, target_dir=tmpdir)
+    assert_is_file(pjoin(tmpdir, 'astsearch.py'))
+    assert_is_file(pjoin(tmpdir, 'astsearch-0.1.2.dist-info', 'METADATA'))
 
-    @pytest.mark.network
-    def test_bad_name(self):
-        # Packages can't be named after stdlib modules like os
-        wl = WheelLocator("os==1.0", "3.5.1", 64)
-        with self.assertRaises(NoWheelError):
-            wl.get_from_pypi()
+@pytest.mark.network
+def test_bad_name():
+    # Packages can't be named after stdlib modules like os
+    wl = WheelLocator("os==1.0", "3.5.1", 64)
+    with pytest.raises(NoWheelError):
+        wl.get_from_pypi()
 
-    @pytest.mark.network
-    def test_bad_version(self):
-        wl = WheelLocator("pynsist==0.99.99", "3.5.1", 64)
-        with self.assertRaises(NoWheelError):
-            wl.get_from_pypi()
+@pytest.mark.network
+def test_bad_version():
+    wl = WheelLocator("pynsist==0.99.99", "3.5.1", 64)
+    with pytest.raises(NoWheelError):
+        wl.get_from_pypi()
 
-    def test_extra_sources(self):
-        with TemporaryDirectory() as td:
-            src1 = Path(td, 'src1')
-            src1.mkdir()
-            src2 = Path(td, 'src2')
-            src2.mkdir()
+def test_extra_sources(tmpdir):
+    src1 = Path(tmpdir, 'src1')
+    src1.mkdir()
+    src2 = Path(tmpdir, 'src2')
+    src2.mkdir()
 
-            # First one found wins, even if a later one is more specific.
-            expected = (src1 / 'astsearch-0.1.2-py3-none-any.whl')
-            expected.touch()
-            (src2 / 'astsearch-0.1.2-py3-none-win_amd64.whl').touch()
-            wl = WheelLocator("astsearch==0.1.2", "3.5.1", 64,
-                            extra_sources=[src1, src2])
-            self.assertEqual(wl.check_extra_sources(), expected)
+    # First one found wins, even if a later one is more specific.
+    expected = (src1 / 'astsearch-0.1.2-py3-none-any.whl')
+    expected.touch()
+    (src2 / 'astsearch-0.1.2-py3-none-win_amd64.whl').touch()
+    wl = WheelLocator("astsearch==0.1.2", "3.5.1", 64,
+                      extra_sources=[src1, src2])
+    assert wl.check_extra_sources() == expected
 
-            wl = WheelLocator("astsearch==0.2.0", "3.5.1", 64,
-                            extra_sources=[src1, src2])
-            self.assertIs(wl.check_extra_sources(), None)
+    wl = WheelLocator("astsearch==0.2.0", "3.5.1", 64,
+                      extra_sources=[src1, src2])
+    assert wl.check_extra_sources() is None
 
-    def test_pick_best_wheel(self):
-        wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
+def test_pick_best_wheel():
+    wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
 
-        # Some of the wheel filenames below are impossible combinations - they are
-        # there to test the scoring and ranking machinery.
+    # Some of the wheel filenames below are impossible combinations - they are
+    # there to test the scoring and ranking machinery.
 
-        # Prefer Windows-specific wheel
-        releases = [
-            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-            CachedRelease('astsearch-0.1.2-py3-none-win_amd64.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
+    # Prefer Windows-specific wheel
+    releases = [
+        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+        CachedRelease('astsearch-0.1.2-py3-none-win_amd64.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[1]
 
-        # Wrong Windows bitness
-        releases = [
-            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-            CachedRelease('astsearch-0.1.2-py3-none-win_32.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
+    # Wrong Windows bitness
+    releases = [
+        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+        CachedRelease('astsearch-0.1.2-py3-none-win_32.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[0]
 
-        # Prefer more specific Python version
-        releases = [
-            CachedRelease('astsearch-0.1.2-cp35-none-any.whl'),
-            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
+    # Prefer more specific Python version
+    releases = [
+        CachedRelease('astsearch-0.1.2-cp35-none-any.whl'),
+        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[0]
 
-        # Prefer more specific Python version
-        releases = [
-            CachedRelease('astsearch-0.1.2-py34.py35-none-any.whl'),
-            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
+    # Prefer more specific Python version
+    releases = [
+        CachedRelease('astsearch-0.1.2-py34.py35-none-any.whl'),
+        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[0]
 
-        # Incompatible Python version
-        releases = [
-            CachedRelease('astsearch-0.1.2-cp33-none-any.whl'),
-            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
+    # Incompatible Python version
+    releases = [
+        CachedRelease('astsearch-0.1.2-cp33-none-any.whl'),
+        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[1]
 
-        # Prefer more specific ABI version
-        releases = [
-            CachedRelease('astsearch-0.1.2-py3-abi3-any.whl'),
-            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
+    # Prefer more specific ABI version
+    releases = [
+        CachedRelease('astsearch-0.1.2-py3-abi3-any.whl'),
+        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[0]
 
-        # Incompatible ABI version
-        releases = [
-            CachedRelease('astsearch-0.1.2-cp35-abi4-win_amd64.whl'),
-            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
+    # Incompatible ABI version
+    releases = [
+        CachedRelease('astsearch-0.1.2-cp35-abi4-win_amd64.whl'),
+        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[1]
 
-        # Platform has priority over other attributes
-        releases = [
-            CachedRelease('astsearch-0.1.2-cp35-abi3-any.whl'),
-            CachedRelease('astsearch-0.1.2-py2.py3-none-win_amd64.whl'),
-        ]
-        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
+    # Platform has priority over other attributes
+    releases = [
+        CachedRelease('astsearch-0.1.2-cp35-abi3-any.whl'),
+        CachedRelease('astsearch-0.1.2-py2.py3-none-win_amd64.whl'),
+    ]
+    assert wd.pick_best_wheel(releases) == releases[1]
 
-    def test_merge_dir_to(self):
-        with TemporaryDirectory() as td1, TemporaryDirectory() as td2:
-            td1 = Path(td1)
-            td2 = Path(td2)
-            with (td1 / 'ab').open('w') as f:
-                f.write(u"original")
-            with (td2 / 'ab').open('w') as f:
-                f.write(u"alternate")
+def test_merge_dir_to(tmpdir_factory):
+    td1 = tmpdir_factory.mktemp('td1')
+    td2 = tmpdir_factory.mktemp('td2')
 
-            (td1 / 'subdir').mkdir()
-            with (td1 / 'subdir' / 'foo').open('w'): pass
-            (td2 / 'subdir').mkdir()
-            with (td2 / 'subdir' / 'bar').open('w'): pass
+    td1 = Path(td1)
+    td2 = Path(td2)
 
-            merge_dir_to(td2, td1)
+    with (td1 / 'ab').open('w') as f:
+        f.write(u"original")
+    with (td2 / 'ab').open('w') as f:
+        f.write(u"alternate")
 
-            assert_isfile(str(td1 / 'subdir' / 'foo'))
-            assert_isfile(str(td1 / 'subdir' / 'bar'))
-            with (td1 / 'ab').open() as f:
-                self.assertEqual(f.read(), u"alternate")
+    (td1 / 'subdir').mkdir()
+    with (td1 / 'subdir' / 'foo').open('w'): pass
+    (td2 / 'subdir').mkdir()
+    with (td2 / 'subdir' / 'bar').open('w'): pass
 
-            # Test with conflicts
-            (td1 / 'conflict').mkdir()
-            with (td2 / 'conflict').open('w'): pass
+    merge_dir_to(td2, td1)
 
-            with self.assertRaises(RuntimeError):
-                merge_dir_to(td2, td1)
-            with self.assertRaises(RuntimeError):
-                merge_dir_to(td1, td2)
+    assert_is_file(str(td1 / 'subdir' / 'foo'))
+    assert_is_file(str(td1 / 'subdir' / 'bar'))
+    with (td1 / 'ab').open() as f:
+        assert f.read() == u"alternate"
+
+    # Test with conflicts
+    (td1 / 'conflict').mkdir()
+    with (td2 / 'conflict').open('w'):
+        pass
+
+    with pytest.raises(RuntimeError):
+        merge_dir_to(td2, td1)
+    with pytest.raises(RuntimeError):
+        merge_dir_to(td1, td2)

--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -112,8 +112,8 @@ def test_pick_best_wheel():
     assert wd.pick_best_wheel(releases) == releases[1]
 
 def test_merge_dir_to(tmpdir):
-    td1 = Path(tmpdir.mkdir('one'))
-    td2 = Path(tmpdir.mkdir('two'))
+    td1 = Path(str(tmpdir.mkdir('one')))
+    td2 = Path(str(tmpdir.mkdir('two')))
 
     with (td1 / 'ab').open('w') as f:
         f.write(u"original")

--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -1,4 +1,6 @@
-from nose.tools import *
+import pytest
+import unittest
+
 from os.path import join as pjoin
 from pathlib import Path
 from testpath import assert_isfile, assert_isdir
@@ -8,139 +10,140 @@ from nsist.pypi import (
     WheelLocator, extract_wheel, CachedRelease, merge_dir_to, NoWheelError,
 )
 
-def test_download():
-    wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
-    wheel = wd.fetch()
-    assert_isfile(str(wheel))
+# To exclude tests requiring network on an unplugged machine, use: pytest -m "not network"
 
-    with TemporaryDirectory() as td:
-        extract_wheel(wheel, target_dir=td)
-        assert_isfile(pjoin(td, 'astsearch.py'))
-        assert_isfile(pjoin(td, 'astsearch-0.1.2.dist-info', 'METADATA'))
+class TestPyPi(unittest.TestCase):
+    @pytest.mark.network
+    def test_download(self):
+        wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
+        wheel = wd.fetch()
+        assert_isfile(str(wheel))
 
-def test_bad_name():
-    # Packages can't be named after stdlib modules like os
-    wl = WheelLocator("os==1.0", "3.5.1", 64)
-    with assert_raises(NoWheelError):
-        wl.get_from_pypi()
+        with TemporaryDirectory() as td:
+            extract_wheel(wheel, target_dir=td)
+            assert_isfile(pjoin(td, 'astsearch.py'))
+            assert_isfile(pjoin(td, 'astsearch-0.1.2.dist-info', 'METADATA'))
 
-def test_bad_version():
-    wl = WheelLocator("pynsist==0.99.99", "3.5.1", 64)
-    with assert_raises(NoWheelError):
-        wl.get_from_pypi()
+    @pytest.mark.network
+    def test_bad_name(self):
+        # Packages can't be named after stdlib modules like os
+        wl = WheelLocator("os==1.0", "3.5.1", 64)
+        with self.assertRaises(NoWheelError):
+            wl.get_from_pypi()
 
-# To exclude these, run:  nosetests -a '!network'
-test_download.network = 1
-test_bad_name.network = 1
-test_bad_version.network = 1
+    @pytest.mark.network
+    def test_bad_version(self):
+        wl = WheelLocator("pynsist==0.99.99", "3.5.1", 64)
+        with self.assertRaises(NoWheelError):
+            wl.get_from_pypi()
 
-def test_extra_sources():
-    with TemporaryDirectory() as td:
-        src1 = Path(td, 'src1')
-        src1.mkdir()
-        src2 = Path(td, 'src2')
-        src2.mkdir()
+    def test_extra_sources(self):
+        with TemporaryDirectory() as td:
+            src1 = Path(td, 'src1')
+            src1.mkdir()
+            src2 = Path(td, 'src2')
+            src2.mkdir()
 
-        # First one found wins, even if a later one is more specific.
-        expected = (src1 / 'astsearch-0.1.2-py3-none-any.whl')
-        expected.touch()
-        (src2 / 'astsearch-0.1.2-py3-none-win_amd64.whl').touch()
-        wl = WheelLocator("astsearch==0.1.2", "3.5.1", 64,
-                          extra_sources=[src1, src2])
-        assert_equal(wl.check_extra_sources(), expected)
+            # First one found wins, even if a later one is more specific.
+            expected = (src1 / 'astsearch-0.1.2-py3-none-any.whl')
+            expected.touch()
+            (src2 / 'astsearch-0.1.2-py3-none-win_amd64.whl').touch()
+            wl = WheelLocator("astsearch==0.1.2", "3.5.1", 64,
+                            extra_sources=[src1, src2])
+            self.assertEqual(wl.check_extra_sources(), expected)
 
-        wl = WheelLocator("astsearch==0.2.0", "3.5.1", 64,
-                          extra_sources=[src1, src2])
-        assert_is(wl.check_extra_sources(), None)
+            wl = WheelLocator("astsearch==0.2.0", "3.5.1", 64,
+                            extra_sources=[src1, src2])
+            self.assertIs(wl.check_extra_sources(), None)
 
-def test_pick_best_wheel():
-    wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
+    def test_pick_best_wheel(self):
+        wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
 
-    # Some of the wheel filenames below are impossible combinations - they are
-    # there to test the scoring and ranking machinery.
+        # Some of the wheel filenames below are impossible combinations - they are
+        # there to test the scoring and ranking machinery.
 
-    # Prefer Windows-specific wheel
-    releases = [
-        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-        CachedRelease('astsearch-0.1.2-py3-none-win_amd64.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[1])
+        # Prefer Windows-specific wheel
+        releases = [
+            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+            CachedRelease('astsearch-0.1.2-py3-none-win_amd64.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
 
-    # Wrong Windows bitness
-    releases = [
-        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-        CachedRelease('astsearch-0.1.2-py3-none-win_32.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[0])
+        # Wrong Windows bitness
+        releases = [
+            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+            CachedRelease('astsearch-0.1.2-py3-none-win_32.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
 
-    # Prefer more specific Python version
-    releases = [
-        CachedRelease('astsearch-0.1.2-cp35-none-any.whl'),
-        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[0])
+        # Prefer more specific Python version
+        releases = [
+            CachedRelease('astsearch-0.1.2-cp35-none-any.whl'),
+            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
 
-    # Prefer more specific Python version
-    releases = [
-        CachedRelease('astsearch-0.1.2-py34.py35-none-any.whl'),
-        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[0])
+        # Prefer more specific Python version
+        releases = [
+            CachedRelease('astsearch-0.1.2-py34.py35-none-any.whl'),
+            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
 
-    # Incompatible Python version
-    releases = [
-        CachedRelease('astsearch-0.1.2-cp33-none-any.whl'),
-        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[1])
+        # Incompatible Python version
+        releases = [
+            CachedRelease('astsearch-0.1.2-cp33-none-any.whl'),
+            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
 
-    # Prefer more specific ABI version
-    releases = [
-        CachedRelease('astsearch-0.1.2-py3-abi3-any.whl'),
-        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[0])
+        # Prefer more specific ABI version
+        releases = [
+            CachedRelease('astsearch-0.1.2-py3-abi3-any.whl'),
+            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[0])
 
-    # Incompatible ABI version
-    releases = [
-        CachedRelease('astsearch-0.1.2-cp35-abi4-win_amd64.whl'),
-        CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[1])
+        # Incompatible ABI version
+        releases = [
+            CachedRelease('astsearch-0.1.2-cp35-abi4-win_amd64.whl'),
+            CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
 
-    # Platform has priority over other attributes
-    releases = [
-        CachedRelease('astsearch-0.1.2-cp35-abi3-any.whl'),
-        CachedRelease('astsearch-0.1.2-py2.py3-none-win_amd64.whl'),
-    ]
-    assert_equal(wd.pick_best_wheel(releases), releases[1])
+        # Platform has priority over other attributes
+        releases = [
+            CachedRelease('astsearch-0.1.2-cp35-abi3-any.whl'),
+            CachedRelease('astsearch-0.1.2-py2.py3-none-win_amd64.whl'),
+        ]
+        self.assertEqual(wd.pick_best_wheel(releases), releases[1])
 
-def test_merge_dir_to():
-    with TemporaryDirectory() as td1, TemporaryDirectory() as td2:
-        td1 = Path(td1)
-        td2 = Path(td2)
-        with (td1 / 'ab').open('w') as f:
-            f.write(u"original")
-        with (td2 / 'ab').open('w') as f:
-            f.write(u"alternate")
+    def test_merge_dir_to(self):
+        with TemporaryDirectory() as td1, TemporaryDirectory() as td2:
+            td1 = Path(td1)
+            td2 = Path(td2)
+            with (td1 / 'ab').open('w') as f:
+                f.write(u"original")
+            with (td2 / 'ab').open('w') as f:
+                f.write(u"alternate")
 
-        (td1 / 'subdir').mkdir()
-        with (td1 / 'subdir' / 'foo').open('w'): pass
-        (td2 / 'subdir').mkdir()
-        with (td2 / 'subdir' / 'bar').open('w'): pass
+            (td1 / 'subdir').mkdir()
+            with (td1 / 'subdir' / 'foo').open('w'): pass
+            (td2 / 'subdir').mkdir()
+            with (td2 / 'subdir' / 'bar').open('w'): pass
 
-        merge_dir_to(td2, td1)
-
-        assert_isfile(str(td1 / 'subdir' / 'foo'))
-        assert_isfile(str(td1 / 'subdir' / 'bar'))
-        with (td1 / 'ab').open() as f:
-            assert_equal(f.read(), u"alternate")
-
-        # Test with conflicts
-        (td1 / 'conflict').mkdir()
-        with (td2 / 'conflict').open('w'): pass
-
-        with assert_raises(RuntimeError):
             merge_dir_to(td2, td1)
-        with assert_raises(RuntimeError):
-            merge_dir_to(td1, td2)
+
+            assert_isfile(str(td1 / 'subdir' / 'foo'))
+            assert_isfile(str(td1 / 'subdir' / 'bar'))
+            with (td1 / 'ab').open() as f:
+                self.assertEqual(f.read(), u"alternate")
+
+            # Test with conflicts
+            (td1 / 'conflict').mkdir()
+            with (td2 / 'conflict').open('w'): pass
+
+            with self.assertRaises(RuntimeError):
+                merge_dir_to(td2, td1)
+            with self.assertRaises(RuntimeError):
+                merge_dir_to(td1, td2)

--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -34,8 +34,8 @@ def test_bad_version():
         wl.get_from_pypi()
 
 def test_extra_sources(tmpdir):
-    src1 = Path(tmpdir.mkdir('src1'))
-    src2 = Path(tmpdir.mkdir('src2'))
+    src1 = Path(str(tmpdir.mkdir('src1')))
+    src2 = Path(str(tmpdir.mkdir('src2')))
 
     # First one found wins, even if a later one is more specific.
     expected = (src1 / 'astsearch-0.1.2-py3-none-any.whl')

--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -11,6 +11,7 @@ from .utils import assert_is_file
 
 @pytest.mark.network
 def test_download(tmpdir):
+    tmpdir = str(tmpdir)
     wd = WheelLocator("astsearch==0.1.2", "3.5.1", 64)
     wheel = wd.fetch()
     assert_is_file(str(wheel))
@@ -33,10 +34,8 @@ def test_bad_version():
         wl.get_from_pypi()
 
 def test_extra_sources(tmpdir):
-    src1 = Path(tmpdir, 'src1')
-    src1.mkdir()
-    src2 = Path(tmpdir, 'src2')
-    src2.mkdir()
+    src1 = Path(tmpdir.mkdir('src1'))
+    src2 = Path(tmpdir.mkdir('src2'))
 
     # First one found wins, even if a later one is more specific.
     expected = (src1 / 'astsearch-0.1.2-py3-none-any.whl')
@@ -112,12 +111,9 @@ def test_pick_best_wheel():
     ]
     assert wd.pick_best_wheel(releases) == releases[1]
 
-def test_merge_dir_to(tmpdir_factory):
-    td1 = tmpdir_factory.mktemp('td1')
-    td2 = tmpdir_factory.mktemp('td2')
-
-    td1 = Path(td1)
-    td2 = Path(td2)
+def test_merge_dir_to(tmpdir):
+    td1 = Path(tmpdir.mkdir('one'))
+    td2 = Path(tmpdir.mkdir('two'))
 
     with (td1 / 'ab').open('w') as f:
         f.write(u"original")

--- a/nsist/tests/utils.py
+++ b/nsist/tests/utils.py
@@ -1,3 +1,6 @@
+import unittest
+import sys
+
 from os.path import isfile, isdir, exists, dirname
 
 test_dir = dirname(__file__)
@@ -9,3 +12,13 @@ def assert_is_file(path):
 def assert_is_dir(path):
     assert exists(path), "%s does not exist"
     assert isdir(path), "%s exists but is not a directory."
+
+def skip_on_windows(function):
+    """Decorator to skip a test on Windows."""
+    return unittest.skipIf(sys.platform.startswith("win"),
+                           "Test for non-Windows platforms")(function)
+
+def only_on_windows(function):
+    """Decorator to skip a test on Windows."""
+    return unittest.skipUnless(sys.platform.startswith("win"),
+                               "Test requires Windows")(function)

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ deps = pytest
        requests_download
        win_cli_launchers
        jinja2
-       yarg 
-       testpath
+       yarg
 commands = pytest nsist/tests
 
 [testenv:notnetwork]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+skipsdist = true
+envlist = python
+
+[testenv]
+deps = pytest
+       requests 
+       requests_download
+       win_cli_launchers
+       jinja2
+       yarg 
+       testpath
+commands = pytest nsist/tests
+
+[testenv:notnetwork]
+commands = pytest -m "not network" nsist/tests


### PR DESCRIPTION
Note: this PR should be merged only after #164, as it includes its changes (everything up to ca76f3c included).

Nose seems to be outdated and not maintained anymore. It is advised on their website to use another test framework. Furthermore I had some difficulties to make nose run correctly tests.

Pytest is the de facto standard test framework in Python. Tox is the widely used tool to prepare test environment for pytest. Both of them are unlikely to be dropped.

This PR implements pytest+tox to be used in the CI systems AppVeyor and Travis. Doing so the test environment is configured in a common location for both Windows and Linux (`tox.ini`). Additionally to the test environment run by default, a `notnetwork` is settled to execute tests on a machine without network: it takes advantage of the pytest marker mechanism, by adding the decorator `@pytest.mark.network` on tests that requires a functional network.

Regards,
Adrien Ferrand