### PR TITLE
Fix adding commands to PATH in a user install

### DIFF
--- a/nsist/_system_path.py
+++ b/nsist/_system_path.py
@@ -184,12 +184,21 @@ def broadcast_environment_settings_change():
 
 
 def main():
+    if len(sys.argv) < 3:
+        sys.exit("Too few arguments: {}".format(sys.argv))
+    elif len(sys.argv) > 3:
+        sys.exit("Too many arguments: {}".format(sys.argv))
+
     if sys.argv[1] == 'add':
         add_to_system_path(sys.argv[2])
-        broadcast_environment_settings_change()
+    elif sys.argv[1] == 'add_user':
+        add_to_system_path(sys.argv[2], allusers=False)
     elif sys.argv[1] == 'remove':
         remove_from_system_path(sys.argv[2])
-        broadcast_environment_settings_change()
+    elif sys.argv[1] == 'remove_user':
+        remove_from_system_path(sys.argv[2], allusers=False)
+
+    broadcast_environment_settings_change()
 
 if __name__ == '__main__':
     main()

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -108,7 +108,15 @@ Section "!${PRODUCT_NAME}" sec_app
   [% if has_commands %]
     DetailPrint "Setting up command-line launchers..."
     nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_assemble_launchers.py" "$INSTDIR\bin"'
-    nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" add "$INSTDIR\bin"'
+
+    StrCmp $MultiUser.InstallMode CurrentUser 0 AddSysPathSystem
+      ; Add to PATH for current user
+      nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" add_user "$INSTDIR\bin"'
+      GoTo AddedSysPath
+    AddSysPathSystem:
+      ; Add to PATH for all users
+      nsExec::ExecToLog '[[ python ]] -Es "$INSTDIR\_system_path.py" add "$INSTDIR\bin"'
+    AddedSysPath:
   [% endif %]
   [% endblock install_commands %]
   


### PR DESCRIPTION
Fixes #167

If you have an application that installs commands, please test this branch! Check out the branch and install Pynsist from it (`flit install`), then use Pynsist to build a new installer. Install it and check that the directory containing exes is added to PATH correctly, then uninstall and check that the directory is removed from PATH again. Try the same with both a single-user installation and an installation for all users.