### PR TITLE
Edit wheels.py to include python 3.8 compatibility for ABI tags witho…

### DIFF
--- a/nsist/wheels.py
+++ b/nsist/wheels.py
@@ -38,7 +38,14 @@ class CompatibilityScorer:
         py_version_nodot = ''.join(self.py_version.split('.')[:2])
         # Are there other valid options here?
         d = {'cp%sm' % py_version_nodot: 3,  # Is the m reliable?
-            'abi3': 2, 'none': 1}
+             'abi3': 2, 'none': 1}
+        try:
+            if int(py_version_nodot) >= 38: #The m is no longer used in Python 3.8+. Now ABI compatible with and without malloc.
+                additional_abi = 'cp%s' % py_version_nodot
+                d[additional_abi] = 4
+        except TypeError:
+            pass
+
         return max(d.get(a, 0) for a in abi.split('.'))
 
     def score_interpreter(self, interpreter):


### PR DESCRIPTION
The changes to ABI flags in python 3.8 make the ABI score/check function in wheels.py fail.
Previous requirements were for "cp{version}m", "abi3" or "none". 

> "Default sys.abiflags became an empty string: the m flag for pymalloc became useless (builds with and without pymalloc are ABI compatible) and so has been removed. (Contributed by Victor Stinner in bpo-36707.)"  
[What's new in Python 3.8](https://docs.python.org/3/whatsnew/3.8.html)

The changes made add an extra allowable option if the python version is 3.8 or greater: 
"cp{version}"