### PR TITLE
Add PRODUCT_PUBLISHER as an NSIS variable

### DIFF
--- a/doc/cfgfile.rst
+++ b/doc/cfgfile.rst
@@ -283,7 +283,8 @@ the line with the key:
      <http://nsis.sourceforge.net/Docs/Chapter4.html#4.2.3>`_, e.g. ``$SYSDIR``.
 
    The destination can also include ``${PRODUCT_NAME}``, which will be expanded
-   to the name of your application.
+   to the name of your application, and ``${PRODUCT_PUBLISHER}``, which will be expanded
+   to the publisher of your application.
 
    For instance, to put a data file in the (32 bit) common files directory:
 

--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -1,5 +1,6 @@
 !define PRODUCT_NAME "[[ib.appname]]"
 !define PRODUCT_VERSION "[[ib.version]]"
+!define PRODUCT_PUBLISHER "[[ib.publisher]"
 !define PY_VERSION "[[ib.py_version]]"
 !define PY_MAJOR_VERSION "[[ib.py_major_version]]"
 !define BITNESS "[[ib.py_bitness]]"


### PR DESCRIPTION
Within the local AppDir on windows, the application author or publisher is often included as the parent path of the product, for example `C:\Users\username\AppData\Local\publisher_or_author\appname`. Thus, exposing the publisher, would allow installation into this hierarchy via something like the following in the pynsist config file:

`filepath > $LOCALAPPDATA/${PRODUCT_PUBLISHER}/${PRODUCT_NAME}`

 
