### PR TITLE
Update cfgfile.rst - boilerplate for script should add pkgs\ as sitedir to load all .pth

### DIFF
--- a/doc/cfgfile.rst
+++ b/doc/cfgfile.rst
@@ -40,8 +40,15 @@ Application section
    Ensure that this boilerplate code is at the top of your script::
 
        #!python3.6
-       import sys
-       sys.path.insert(0, 'pkgs')
+       import sys, os
+       import site
+
+       scriptdir, script = os.path.split(__file__)
+       installdir = scriptdir  # for compatibility with commands
+       pkgdir = os.path.join(scriptdir, 'pkgs')
+       # Ensure .pth files in pkgdir are handled properly
+       site.addsitedir(pkgdir)
+       sys.path.insert(0, pkgdir)
 
    The first line tells it which version of Python to run with. If you use
    binary packages, packages compiled for Python 3.3 won't work with Python 3.4.

--- a/doc/cfgfile.rst
+++ b/doc/cfgfile.rst
@@ -44,7 +44,6 @@ Application section
        import site
 
        scriptdir, script = os.path.split(__file__)
-       installdir = scriptdir  # for compatibility with commands
        pkgdir = os.path.join(scriptdir, 'pkgs')
        # Ensure .pth files in pkgdir are handled properly
        site.addsitedir(pkgdir)


### PR DESCRIPTION
I had some problems with the win32api module not being found. I traced it to the `.pth` files not being run, which i believe the above changes address https://pynsist.readthedocs.io/en/latest/_modules/nsist.html