### PR TITLE
No ABI suffix in wheel names on Python >=3.8

### DIFF
--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -50,8 +50,8 @@ def test_extra_sources(tmpdir):
     assert wl.check_extra_sources() is None
 
 def test_pick_best_wheel():
-    wd = WheelLocator("astsearch==0.1.2",
-                      CompatibilityScorer("3.5.1", "win_amd64"))
+    wd37 = WheelLocator("astsearch==0.1.2", CompatibilityScorer("3.7.1", "win_amd64"))
+    wd38 = WheelLocator("astsearch==0.1.2", CompatibilityScorer("3.8.0", "win_amd64"))
 
     # Some of the wheel filenames below are impossible combinations - they are
     # there to test the scoring and ranking machinery.
@@ -61,56 +61,70 @@ def test_pick_best_wheel():
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-win_amd64.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[1]
+    assert wd37.pick_best_wheel(releases) == releases[1]
 
     # Wrong Windows bitness
     releases = [
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-win_32.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[0]
+    assert wd37.pick_best_wheel(releases) == releases[0]
 
     # Prefer more specific Python version
     releases = [
-        CachedRelease('astsearch-0.1.2-cp35-none-any.whl'),
+        CachedRelease('astsearch-0.1.2-cp37-none-any.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[0]
+    assert wd37.pick_best_wheel(releases) == releases[0]
 
     # Prefer more specific Python version
     releases = [
-        CachedRelease('astsearch-0.1.2-py34.py35-none-any.whl'),
+        CachedRelease('astsearch-0.1.2-py34.py37-none-any.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[0]
+    assert wd37.pick_best_wheel(releases) == releases[0]
 
     # Incompatible Python version
     releases = [
         CachedRelease('astsearch-0.1.2-cp33-none-any.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[1]
+    assert wd37.pick_best_wheel(releases) == releases[1]
 
     # Prefer more specific ABI version
     releases = [
         CachedRelease('astsearch-0.1.2-py3-abi3-any.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[0]
+    assert wd37.pick_best_wheel(releases) == releases[0]
+
+    # ABI suffix on Python <3.8
+    releases = [
+        CachedRelease('astsearch-0.1.2-cp37-cp37-any.whl'),
+        CachedRelease('astsearch-0.1.2-cp37-cp37m-any.whl'),
+    ]
+    assert wd37.pick_best_wheel(releases) == releases[1]
+
+    # No ABI suffix on Python >=3.8
+    releases = [
+        CachedRelease('astsearch-0.1.2-cp38-cp38-any.whl'),
+        CachedRelease('astsearch-0.1.2-cp38-cp38m-any.whl'),
+    ]
+    assert wd38.pick_best_wheel(releases) == releases[0]
 
     # Incompatible ABI version
     releases = [
-        CachedRelease('astsearch-0.1.2-cp35-abi4-win_amd64.whl'),
+        CachedRelease('astsearch-0.1.2-cp37-abi4-win_amd64.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[1]
+    assert wd37.pick_best_wheel(releases) == releases[1]
 
     # Platform has priority over other attributes
     releases = [
-        CachedRelease('astsearch-0.1.2-cp35-abi3-any.whl'),
+        CachedRelease('astsearch-0.1.2-cp37-abi3-any.whl'),
         CachedRelease('astsearch-0.1.2-py2.py3-none-win_amd64.whl'),
     ]
-    assert wd.pick_best_wheel(releases) == releases[1]
+    assert wd37.pick_best_wheel(releases) == releases[1]
 
 def test_merge_dir_to(tmpdir):
     td1 = Path(str(tmpdir.mkdir('one')))

--- a/nsist/wheels.py
+++ b/nsist/wheels.py
@@ -27,6 +27,7 @@ class CompatibilityScorer:
     """
     def __init__(self, py_version, platform):
         self.py_version = py_version
+        self.py_version_tuple = tuple(map(int, py_version.split('.')[:2]))
         self.platform = platform
 
     def score_platform(self, platform):
@@ -35,15 +36,17 @@ class CompatibilityScorer:
         return max(d.get(p, 0) for p in platform.split('.'))
 
     def score_abi(self, abi):
-        py_version_nodot = ''.join(self.py_version.split('.')[:2])
+        py_version_nodot = '%s%s' % (self.py_version_tuple[0], self.py_version_tuple[1])
+        abi_suffix = 'm' if self.py_version_tuple < (3, 8) else ''
         # Are there other valid options here?
-        d = {'cp%sm' % py_version_nodot: 3,  # Is the m reliable?
-            'abi3': 2, 'none': 1}
+        d = {'cp%s%s' % (py_version_nodot, abi_suffix): 3,
+             'abi3': 2,
+             'none': 1}
         return max(d.get(a, 0) for a in abi.split('.'))
 
     def score_interpreter(self, interpreter):
-        py_version_nodot = ''.join(self.py_version.split('.')[:2])
-        py_version_major = self.py_version.split('.')[0]
+        py_version_nodot = '%s%s' % (self.py_version_tuple[0], self.py_version_tuple[1])
+        py_version_major = str(self.py_version_tuple[0])
         d = {'cp'+py_version_nodot: 4,
              'cp'+py_version_major: 3,
              'py'+py_version_nodot: 2,


### PR DESCRIPTION
This removes the "m" suffix from the CPython ABI tags in the `CompatibilityScorer.score_abi` method if the python version is `>=3.8`.

In comparison to PR #192, this PR
- compares the python versions as a tuple of integers
- doesn't add the suffix-less name as a higher score item, as ABI suffixes shouldn't exist on `>=3.8`
  (if this is wrong or you want to have full compatibility, even for "invalid" names, then I can of course update this)
- adds/updates tests

----

- https://docs.python.org/3/whatsnew/3.8.html#build-and-c-api-changes
- https://github.com/pypa/wheel/blame/0.35.1/docs/news.rst#L54
- https://github.com/pypa/wheel/blob/0.35.1/src/wheel/bdist_wheel.py#L80-L85