### PR TITLE
Handle properly compatibility for wheels of ABI type "abi3"

### DIFF
--- a/nsist/tests/test_local_wheels.py
+++ b/nsist/tests/test_local_wheels.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import platform
 import subprocess
+from unittest import mock
 from zipfile import ZipFile
 
 import pytest
@@ -11,6 +12,7 @@ from testpath import assert_isfile, assert_isdir, assert_not_path_exists
 from nsist.wheels import WheelGetter, extract_wheel
 
 # To exclude tests requiring network on an unplugged machine, use: pytest -m "not network"
+
 
 @pytest.mark.network
 def test_matching_one_pattern(tmpdir):
@@ -28,6 +30,7 @@ def test_matching_one_pattern(tmpdir):
     assert_isdir(os.path.join(td2, 'urllib3'))
     assert glob.glob(os.path.join(td2, 'urllib3*.dist-info'))
 
+
 @pytest.mark.network
 def test_duplicate_wheel_files_raise(tmpdir):
     td1 = str(tmpdir.mkdir('wheels'))
@@ -41,6 +44,7 @@ def test_duplicate_wheel_files_raise(tmpdir):
     with pytest.raises(ValueError, match='Multiple wheels specified'):
         wg.get_all()
 
+
 def test_invalid_wheel_file_raise(tmpdir):
     td1 = str(tmpdir.mkdir('wheels'))
     td2 = str(tmpdir.mkdir('pkgs'))
@@ -53,6 +57,7 @@ def test_invalid_wheel_file_raise(tmpdir):
     with pytest.raises(ValueError, match='notawheel.txt'):
         wg.get_globs()
 
+
 def test_incompatible_platform_wheel_file_raise(tmpdir):
     td1 = str(tmpdir.mkdir('wheels'))
     td2 = str(tmpdir.mkdir('pkgs'))
@@ -64,6 +69,7 @@ def test_incompatible_platform_wheel_file_raise(tmpdir):
 
     with pytest.raises(ValueError, match='not compatible with .* win_amd64'):
         wg.get_globs()
+
 
 def test_incompatible_python_wheel_file_raise(tmpdir):
     td1 = str(tmpdir.mkdir('wheels'))
@@ -78,6 +84,33 @@ def test_incompatible_python_wheel_file_raise(tmpdir):
                        .format(platform.python_version())):
         wg.get_globs()
 
+
+def test_abi3_wheel_file_not_raise(tmpdir):
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
+
+    Path(td1, 'wheel-1.0.0-cp36-abi3-win_amd64.whl').touch()
+
+    wg = WheelGetter([], [os.path.join(td1, '*.whl')], td2,
+                     "3.8.6", 64)
+
+    with mock.patch("nsist.wheels.extract_wheel"):
+        wg.get_globs()
+
+
+def test_abi3_wheel_file_raise(tmpdir):
+    td1 = str(tmpdir.mkdir('wheels'))
+    td2 = str(tmpdir.mkdir('pkgs'))
+
+    Path(td1, 'wheel-1.0.0-cp39-abi3-win_amd64.whl').touch()
+
+    wg = WheelGetter([], [os.path.join(td1, '*.whl')], td2,
+                     "3.8.6", 64)
+
+    with pytest.raises(ValueError, match='not compatible with Python 3.8.6'):
+        wg.get_globs()
+
+
 def test_useless_wheel_glob_path_raise(tmpdir):
     td1 = str(tmpdir.mkdir('wheels'))
     td2 = str(tmpdir.mkdir('pkgs'))
@@ -86,6 +119,7 @@ def test_useless_wheel_glob_path_raise(tmpdir):
 
     with pytest.raises(ValueError, match='does not match any files'):
         wg.get_globs()
+
 
 def test_extract_exclude_folder(tmpdir):
     whl_file = str(tmpdir / 'foo.whl')
@@ -99,6 +133,7 @@ def test_extract_exclude_folder(tmpdir):
 
     assert_isfile(str(pkgs / 'foo' / 'bar.txt'))
     assert_not_path_exists(str(pkgs / 'foo' / 'bar'))
+
 
 def test_extract_data_lib_sitepkg(tmpdir):
     whl_file = str(tmpdir / 'foo.whl')

--- a/nsist/tests/test_pypi.py
+++ b/nsist/tests/test_pypi.py
@@ -10,6 +10,7 @@ from nsist.wheels import (
 
 # To exclude tests requiring network on an unplugged machine, use: pytest -m "not network"
 
+
 @pytest.mark.network
 def test_download(tmpdir):
     tmpdir = str(tmpdir)
@@ -21,6 +22,7 @@ def test_download(tmpdir):
     assert_isfile(pjoin(tmpdir, 'astsearch.py'))
     assert_isfile(pjoin(tmpdir, 'astsearch-0.1.2.dist-info', 'METADATA'))
 
+
 @pytest.mark.network
 def test_bad_name():
     # Packages can't be named after stdlib modules like os
@@ -28,11 +30,13 @@ def test_bad_name():
     with pytest.raises(NoWheelError):
         wl.get_from_pypi()
 
+
 @pytest.mark.network
 def test_bad_version():
     wl = WheelLocator("pynsist==0.99.99", "3.5.1", 64)
     with pytest.raises(NoWheelError):
         wl.get_from_pypi()
+
 
 def test_extra_sources(tmpdir):
     src1 = Path(str(tmpdir.mkdir('src1')))
@@ -48,6 +52,7 @@ def test_extra_sources(tmpdir):
 
     wl = WheelLocator("astsearch==0.2.0", scorer, extra_sources=[src1, src2])
     assert wl.check_extra_sources() is None
+
 
 def test_pick_best_wheel():
     wd37 = WheelLocator("astsearch==0.1.2", CompatibilityScorer("3.7.1", "win_amd64"))
@@ -93,10 +98,17 @@ def test_pick_best_wheel():
 
     # Prefer more specific ABI version
     releases = [
-        CachedRelease('astsearch-0.1.2-py3-abi3-any.whl'),
+        CachedRelease('astsearch-0.1.2-cp33-abi3-any.whl'),
         CachedRelease('astsearch-0.1.2-py3-none-any.whl'),
     ]
     assert wd37.pick_best_wheel(releases) == releases[0]
+
+    # Prefer more up-to-date ABI version
+    releases = [
+        CachedRelease('astsearch-0.1.2-cp33-abi3-any.whl'),
+        CachedRelease('astsearch-0.1.2-cp36-abi3-any.whl'),
+    ]
+    assert wd38.pick_best_wheel(releases) == releases[1]
 
     # ABI suffix on Python <3.8
     releases = [
@@ -125,6 +137,7 @@ def test_pick_best_wheel():
         CachedRelease('astsearch-0.1.2-py2.py3-none-win_amd64.whl'),
     ]
     assert wd37.pick_best_wheel(releases) == releases[1]
+
 
 def test_merge_dir_to(tmpdir):
     td1 = Path(str(tmpdir.mkdir('one')))

--- a/nsist/wheels.py
+++ b/nsist/wheels.py
@@ -85,8 +85,6 @@ class CompatibilityScorer:
         else:
             interpreter_score = self.score_interpreter(interpreter)
 
-        print(interpreter_score)
-
         return (
             self.score_platform(platform),
             self.score_abi(abi),
@@ -97,6 +95,7 @@ class CompatibilityScorer:
 class WheelLocator(object):
     def __init__(self, requirement, scorer, extra_sources=None):
         self.requirement = requirement
+        self.scorer = scorer
         self.scorer = scorer
         self.extra_sources = extra_sources or []
 


### PR DESCRIPTION
Wheels whose ABI tag is `abi3` are wheels compiled against the Stable Application Binary Interface: with dedicated compiler tags set, a given non-universal wheel is ensured to work on a wide range of Python version for the target platform (this mechanism is available on Linux and Windows).

By default the compatibility is provided for Python 3.2+. However a developer can decide to compile against a more up-to-date set of a stable interfaces that are available only starting to a more recent version of Python. In this case, the interpreter flag located before the ABI tag is set to that version of Python (eg. `cp36` for Python 3.6).

Finally a tag like `cp36-abi3` must be read as: for the specified platform, this non-universal wheel is compatible with all Python 3.6+ versions.

See https://docs.python.org/3/c-api/stable.html and https://www.python.org/dev/peps/pep-0425/

This approach is taken by the cryptography project, which exposes (since version 3.3) one unique abi3 compatible wheel for each Windows platform: `cryptography-X.X-cp36-abi3-win32.whl` and `cryptography-X.X-cp36-abi3-win_amd64.whl`.

Currently pynsist does not take this into account, and always reads the interpreter flag as a strict requirement for the Python version (eg. `cp36` gives a compatibility for Python 3.6 _only_).

My PR modifies the `CompatibilityScorer` class to take this specification into account: when the ABI tag is `abi3`, the interpreter tag is evaluated as a lower bound for the Python version instead of a strict requirement. I also calculate a score that will favor the most recent Python version propose amoung the wheels (eg. `cp38-abi3` will be prefered over `cp36-abi3` if these two wheels exist for a package).

Basic unit tests are also provided.