### PR TITLE
docs: fix simple typo, conists -> consists

### DIFF
--- a/examples/pygi_mpl_numpy/pygi_test.py
+++ b/examples/pygi_mpl_numpy/pygi_test.py
@@ -3,7 +3,7 @@
 """
 This test program utilizes the Python bindings for GTK3 (PyGI or PyGObject).
 
-The program conists of a window with a button that closes the window when
+The program consists of a window with a button that closes the window when
 clicked. The window also shows a matplotlib plot. The plot is based on this
 example: http://matplotlib.org/examples/pie_and_polar_charts/polar_bar_demo.html
 """


### PR DESCRIPTION
There is a small typo in examples/pygi_mpl_numpy/pygi_test.py.

Closes #229