### PR TITLE
updated packages of the pyqt5 example

### DIFF
--- a/examples/pyqt5/installer.cfg
+++ b/examples/pyqt5/installer.cfg
@@ -4,11 +4,12 @@ version=1.0
 entry_point=listapp:main
 
 [Python]
-version=3.5.1
+version=3.8.7
 bitness=64
 format=bundled
 
 [Include]
 packages=listapp
-pypi_wheels= PyQt5==5.6
-    sip==4.18
+pypi_wheels= pyqt5==5.15.6
+    pyqt5-qt5==5.15.2
+    pyqt5-sip==12.9.0


### PR DESCRIPTION
Python and PyQt5 versions were maxed out for Windows 7 compatibility. See https://github.com/takluyver/pynsist/issues/239