### PR TITLE
Add install_pkgs block to pyapp.nsi template

### DIFF
--- a/nsist/pyapp.nsi
+++ b/nsist/pyapp.nsi
@@ -66,8 +66,24 @@ Section "!${PRODUCT_NAME}" sec_app
   SetRegView [[ib.py_bitness]]
   SectionIn RO
   File ${PRODUCT_ICON}
-  SetOutPath "$INSTDIR\pkgs"
-  File /r "pkgs\*.*"
+
+  [% block install_pkgs %]
+    [#
+      Extend this block if you need to remove the pkgs directory if it already
+      exists from previous installations (when upgrading without uninstalling).
+      https://github.com/takluyver/pynsist/issues/66
+
+      Example:
+      [% block install_pkgs %]
+        RMDir /r "$INSTDIR\pkgs"
+        [[ super() ]]
+      [% endblock install_pkgs %]
+    #]
+    ; Copy pkgs data
+    SetOutPath "$INSTDIR\pkgs"
+    File /r "pkgs\*.*"
+  [% endblock install_pkgs %]
+
   SetOutPath "$INSTDIR"
 
   ; Marker file for per-user install


### PR DESCRIPTION
See https://github.com/takluyver/pynsist/issues/66#issuecomment-1072518911

I've added a template comment with an example to make the intentions as clear as possible. If you don't agree with this, I will remove it again.

I'd also very much appreciate a new release if this gets merged, so that I can continue with my work and remove the ugly workaround we've been using in our installer. Thanks!