### PR TITLE
Provide extra_index_urls in config

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -358,7 +358,7 @@ if __name__ == '__main__':
         wg = WheelGetter(self.pypi_wheel_reqs, self.local_wheels, build_pkg_dir,
                          py_version=self.py_version, bitness=self.py_bitness,
                          extra_sources=self.extra_wheel_sources,
-                         extra_index_urls=self.extra_index_urls,
+                         extra_indexes=self.extra_index_urls,
                          exclude=self.exclude)
         wg.get_all()
 

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -89,6 +89,8 @@ class InstallerBuilder(object):
     :param list pypi_wheel_reqs: Package specifications to fetch from PyPI as wheels
     :param extra_wheel_sources: Directory paths to find wheels in.
     :type extra_wheel_sources: list of Path objects
+    :param extra_index_urls: URLs to alternative package indexes to find wheels.
+    :type extra_index_urls: list of str
     :param local_wheels: Glob paths matching wheel files to include
     :type local_wheels: list of str
     :param list extra_files: List of 2-tuples (file, destination) of files to include

--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -111,7 +111,7 @@ class InstallerBuilder(object):
                 py_format='bundled', inc_msvcrt=True, build_dir=DEFAULT_BUILD_DIR,
                 installer_name=None, nsi_template=None,
                 exclude=None, pypi_wheel_reqs=None, extra_wheel_sources=None,
-                local_wheels=None, commands=None, license_file=None):
+                extra_index_urls=None, local_wheels=None, commands=None, license_file=None):
         self.appname = appname
         self.version = version
         self.publisher = publisher
@@ -122,6 +122,7 @@ class InstallerBuilder(object):
         self.extra_files = extra_files or []
         self.pypi_wheel_reqs = pypi_wheel_reqs or []
         self.extra_wheel_sources = extra_wheel_sources or []
+        self.extra_index_urls = extra_index_urls or []
         self.local_wheels = local_wheels or []
         self.commands = commands or {}
         self.license_file = license_file
@@ -357,6 +358,7 @@ if __name__ == '__main__':
         wg = WheelGetter(self.pypi_wheel_reqs, self.local_wheels, build_pkg_dir,
                          py_version=self.py_version, bitness=self.py_bitness,
                          extra_sources=self.extra_wheel_sources,
+                         extra_index_urls=self.extra_index_urls,
                          exclude=self.exclude)
         wg.get_all()
 

--- a/nsist/configreader.py
+++ b/nsist/configreader.py
@@ -74,6 +74,7 @@ CONFIG_VALIDATORS = {
         ('packages', False),
         ('pypi_wheels', False),
         ('extra_wheel_sources', False),
+        ('extra_index_urls', False),
         ('files', False),
         ('exclude', False),
         ('local_wheels', False)
@@ -230,6 +231,7 @@ def get_installer_builder_args(config):
     args['extra_wheel_sources'] = [Path(p) for p in
         config.get('Include', 'extra_wheel_sources', fallback='').strip().splitlines()
     ]
+    args['extra_index_urls'] = config.get('Include', 'extra_index_urls', fallback='').strip().splitlines()
     args['extra_files'] = read_extra_files(config)
     args['py_version'] = config.get('Python', 'version', fallback=DEFAULT_PY_VERSION)
     args['py_bitness'] = config.getint('Python', 'bitness', fallback=DEFAULT_BITNESS)

--- a/nsist/wheels.py
+++ b/nsist/wheels.py
@@ -327,7 +327,7 @@ class WheelGetter:
 
     def get_requirements(self):
         for req in self.requirements:
-            wl = WheelLocator(req, self.scorer, self.extra_sources, self.extra_indexes))
+            wl = WheelLocator(req, self.scorer, self.extra_sources, self.extra_indexes)
             whl_file = wl.fetch()
             extract_wheel(whl_file, self.target_dir, exclude=self.exclude)
             self.got_distributions[wl.name] = whl_file

--- a/nsist/wheels.py
+++ b/nsist/wheels.py
@@ -144,7 +144,7 @@ class WheelLocator(object):
         """
         return self.get_from_package_index()
 
-    def get_from_package_index(self, index_url):
+    def get_from_package_index(self, index_url=None):
         """Download a compatible wheel from a package index at 'index_url'.
 
         Downloads to the cache directory and returns the destination as a Path.


### PR DESCRIPTION
This is in analogy to the pip option '--extra-index-urls'. 

A custom package index must provide a PyPI interface, i.e. provide a json description such as `https://pypi.org/pypi/numpy/json`. This is a limitation of [yarg](https://github.com/kura/yarg/blob/main/yarg/client.py).

A self signed certificate can be used with `set REQUESTS_CA_BUNDLE=path/to/bundle.pem`, see [here](https://stackoverflow.com/a/43935319/9257878).