### PR TITLE
Fix shortcut target path when using script

### DIFF
--- a/nsist/__init__.py
+++ b/nsist/__init__.py
@@ -316,8 +316,9 @@ if __name__ == '__main__':
 
                 target = '$INSTDIR\\Python\\python{}.exe'
                 sc['target'] = target.format('' if sc['console'] else 'w')
+                sc['script'] = os.path.basename(sc['script'])
                 sc['parameters'] = '"%s"' % ntpath.join('$INSTDIR', sc['script'])
-                files.add(os.path.basename(sc['script']))
+                files.add(sc['script'])
 
             shutil.copy2(sc['icon'], self.build_dir)
             sc['icon'] = os.path.basename(sc['icon'])


### PR DESCRIPTION
In script mode, previously the shortcut would use the entire path provided in the config file rather than the filename of the script, resulting in a broken path and useless shortcut

Previous NSIS script
``` 
  ; Install shortcuts
  ; The output path becomes the working directory for shortcuts
  SetOutPath "%HOMEDRIVE%\%HOMEPATH%"
    CreateShortCut "$SMPROGRAMS\MyScript.lnk" "$INSTDIR\Python\pythonw.exe" \
      '"$INSTDIR\../scripts/script.py"' "$INSTDIR\glossyorb.ico"
  SetOutPath "$INSTDIR"
```

New NSIS script
```
  ; Install shortcuts
  ; The output path becomes the working directory for shortcuts
  SetOutPath "%HOMEDRIVE%\%HOMEPATH%"
    CreateShortCut "$SMPROGRAMS\MyScript.lnk" "$INSTDIR\Python\pythonw.exe" \
      '"$INSTDIR\script.py"' "$INSTDIR\glossyorb.ico"
  SetOutPath "$INSTDIR"

```